### PR TITLE
Display Frequency Distribution

### DIFF
--- a/afp-project.cabal
+++ b/afp-project.cabal
@@ -104,7 +104,8 @@ executable afp-project
     -- Modules included in this executable, other than Main.
     other-modules: Database,
                    Database.Models,
-                   Server
+                   Server,
+                   TestServer
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:

--- a/app/Server.hs
+++ b/app/Server.hs
@@ -60,6 +60,7 @@ getDelays (DelayRequest departure destination bus weekday hour minute) = do
   end_delay <- get False
   return Delays {departureDelays = toDelayFrequencies start_delay, destinationDelays = toDelayFrequencies end_delay}
   where
+    -- Would have added these two to MessageFormat.hs, but Frequency is the App source, not the Lib source
     toDelayFrequencies fs = sortOn punct $ map toDelayFrequency fs
     toDelayFrequency (Frequency _ p f) = DelayFrequency p f
     get get_start =

--- a/app/Server.hs
+++ b/app/Server.hs
@@ -15,6 +15,7 @@ import MessageFormat
       toStopPair,
       toBusPair,
       parseDelayRequest )
+import TestServer
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Handler.Warp

--- a/app/TestServer.hs
+++ b/app/TestServer.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+module TestServer where
+
+import Data.Aeson
+import ExampleData
+import MessageFormat
+import Network.HTTP.Types
+import Network.Wai
+
+-- | Server that responds with example data
+testApp :: Application
+testApp req respond = do
+  print req
+  case pathInfo req of
+    ["stops"] ->
+        respond $ responseLBS status200 [(hContentType, "application/json")] $ encode stopData
+    ["buses"] ->
+        respond $ responseLBS status200 [(hContentType, "application/json")] $ encode busData
+    ["delays"] -> respond $ responseLBS status200 [(hContentType, "application/json")] $ encode delayData

--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -6,6 +6,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "data-viz-lab/elm-chart-builder": "7.0.2",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
@@ -15,9 +16,36 @@
             "elm/url": "1.0.0"
         },
         "indirect": {
+            "K-Adam/elm-dom": "1.0.0",
+            "RalfNorthman/elm-lttb": "1.0.3",
+            "avh4/elm-color": "1.0.0",
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/virtual-dom": "1.0.3"
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/svg": "1.0.1",
+            "elm/virtual-dom": "1.0.3",
+            "elm-community/list-extra": "8.7.0",
+            "elm-community/typed-svg": "6.0.0",
+            "elmcraft/core-extra": "2.0.0",
+            "folkertdev/elm-deque": "3.0.1",
+            "folkertdev/one-true-path-experiment": "6.0.0",
+            "folkertdev/svg-path-lowlevel": "4.0.1",
+            "gampleman/elm-rosetree": "1.1.0",
+            "gampleman/elm-visualization": "2.4.1",
+            "ianmackenzie/elm-1d-parameter": "1.0.1",
+            "ianmackenzie/elm-float-extra": "1.1.0",
+            "ianmackenzie/elm-geometry": "3.11.0",
+            "ianmackenzie/elm-interval": "3.1.0",
+            "ianmackenzie/elm-triangular-mesh": "1.1.0",
+            "ianmackenzie/elm-units": "2.10.0",
+            "ianmackenzie/elm-units-interval": "3.2.0",
+            "ianmackenzie/elm-units-prefixed": "2.8.0",
+            "justinmimbs/date": "4.1.0",
+            "justinmimbs/time-extra": "1.2.0",
+            "rtfeldman/elm-hex": "1.0.0",
+            "ryan-haskell/date-format": "1.0.0"
         }
     },
     "test-dependencies": {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6352,19 +6352,19 @@ var $elm$url$Url$Builder$int = F2(
 var $author$project$Msg$toDayNumber = function (t) {
 	switch (t.$) {
 		case 'Mon':
-			return 0;
-		case 'Tue':
 			return 1;
-		case 'Wed':
+		case 'Tue':
 			return 2;
-		case 'Thu':
+		case 'Wed':
 			return 3;
-		case 'Fri':
+		case 'Thu':
 			return 4;
-		case 'Sat':
+		case 'Fri':
 			return 5;
-		default:
+		case 'Sat':
 			return 6;
+		default:
+			return 7;
 	}
 };
 var $author$project$Main$requestDelays = function (_v0) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5514,10 +5514,6 @@ var $author$project$Main$subscriptions = function (model) {
 	return $elm$core$Platform$Sub$none;
 };
 var $author$project$Model$Loading = {$: 'Loading'};
-var $author$project$Msg$ValidateBus = {$: 'ValidateBus'};
-var $author$project$Msg$ValidateStop = function (a) {
-	return {$: 'ValidateStop', a: a};
-};
 var $author$project$Main$addMinute = F2(
 	function (_v0, x) {
 		var m = _v0.a;
@@ -6704,209 +6700,181 @@ var $author$project$Main$tryParseStop = F2(
 	});
 var $author$project$Main$update = F2(
 	function (msg, _v0) {
-		update:
-		while (true) {
-			var m = _v0.a;
-			switch (msg.$) {
-				case 'NewTime':
-					var t = msg.a;
-					var z = msg.b;
+		var m = _v0.a;
+		switch (msg.$) {
+			case 'NewTime':
+				var t = msg.a;
+				var z = msg.b;
+				return _Utils_Tuple2(
+					$author$project$Model$Model(
+						_Utils_update(
+							m,
+							{
+								momentInWeek: $author$project$Model$MomentInWeek(
+									{
+										day: A2($elm$time$Time$toWeekday, z, t),
+										hour: A2($elm$time$Time$toHour, z, t),
+										minute: A2($elm$time$Time$toMinute, z, t)
+									}),
+								time: _Utils_Tuple2(t, z)
+							})),
+					$author$project$Main$requestStops);
+			case 'GotStops':
+				var res = msg.a;
+				if (res.$ === 'Ok') {
+					var stops = res.a;
 					return _Utils_Tuple2(
 						$author$project$Model$Model(
 							_Utils_update(
 								m,
 								{
-									momentInWeek: $author$project$Model$MomentInWeek(
-										{
-											day: A2($elm$time$Time$toWeekday, z, t),
-											hour: A2($elm$time$Time$toHour, z, t),
-											minute: A2($elm$time$Time$toMinute, z, t)
-										}),
-									time: _Utils_Tuple2(t, z)
+									stops: $author$project$Main$toDict(stops)
 								})),
-						$author$project$Main$requestStops);
-				case 'GotStops':
-					var res = msg.a;
-					if (res.$ === 'Ok') {
-						var stops = res.a;
-						return _Utils_Tuple2(
-							$author$project$Model$Model(
-								_Utils_update(
-									m,
-									{
-										stops: $author$project$Main$toDict(stops)
-									})),
-							$author$project$Main$requestBuses);
-					} else {
-						return _Utils_Tuple2(
-							$author$project$Model$Model(m),
-							$elm$core$Platform$Cmd$none);
-					}
-				case 'GotBuses':
-					var res = msg.a;
-					if (res.$ === 'Ok') {
-						var buses = res.a;
-						return _Utils_Tuple2(
-							$author$project$Model$Model(
-								_Utils_update(
-									m,
-									{
-										buses: $author$project$Main$toDict(buses)
-									})),
-							$elm$core$Platform$Cmd$none);
-					} else {
-						return _Utils_Tuple2(
-							$author$project$Model$Model(m),
-							$elm$core$Platform$Cmd$none);
-					}
-				case 'TimeChange':
-					var t = msg.a;
+						$author$project$Main$requestBuses);
+				} else {
+					return _Utils_Tuple2(
+						$author$project$Model$Model(m),
+						$elm$core$Platform$Cmd$none);
+				}
+			case 'GotBuses':
+				var res = msg.a;
+				if (res.$ === 'Ok') {
+					var buses = res.a;
 					return _Utils_Tuple2(
 						$author$project$Model$Model(
 							_Utils_update(
 								m,
 								{
-									momentInWeek: function () {
-										switch (t.$) {
-											case 'Minus5Min':
-												return A2($author$project$Main$subMinute, m.momentInWeek, 5);
-											case 'Minus15Min':
-												return A2($author$project$Main$subMinute, m.momentInWeek, 15);
-											case 'MinusHour':
-												return A2($author$project$Main$subMinute, m.momentInWeek, 60);
-											case 'Plus5Min':
-												return A2($author$project$Main$addMinute, m.momentInWeek, 5);
-											case 'Plus15Min':
-												return A2($author$project$Main$addMinute, m.momentInWeek, 15);
-											default:
-												return A2($author$project$Main$addMinute, m.momentInWeek, 60);
-										}
-									}()
+									buses: $author$project$Main$toDict(buses)
 								})),
 						$elm$core$Platform$Cmd$none);
-				case 'DayChange':
-					var d = msg.a;
+				} else {
 					return _Utils_Tuple2(
-						$author$project$Model$Model(
-							_Utils_update(
-								m,
-								{
-									momentInWeek: function (_v5) {
-										var momentInWeek = _v5.a;
-										return $author$project$Model$MomentInWeek(
-											_Utils_update(
-												momentInWeek,
-												{day: d}));
-									}(m.momentInWeek)
-								})),
+						$author$project$Model$Model(m),
 						$elm$core$Platform$Cmd$none);
-				case 'StopChange':
-					var x = msg.a;
-					var d = msg.b;
-					var updated_model = $author$project$Model$Model(
+				}
+			case 'TimeChange':
+				var t = msg.a;
+				return _Utils_Tuple2(
+					$author$project$Model$Model(
+						_Utils_update(
+							m,
+							{
+								momentInWeek: function () {
+									switch (t.$) {
+										case 'Minus5Min':
+											return A2($author$project$Main$subMinute, m.momentInWeek, 5);
+										case 'Minus15Min':
+											return A2($author$project$Main$subMinute, m.momentInWeek, 15);
+										case 'MinusHour':
+											return A2($author$project$Main$subMinute, m.momentInWeek, 60);
+										case 'Plus5Min':
+											return A2($author$project$Main$addMinute, m.momentInWeek, 5);
+										case 'Plus15Min':
+											return A2($author$project$Main$addMinute, m.momentInWeek, 15);
+										default:
+											return A2($author$project$Main$addMinute, m.momentInWeek, 60);
+									}
+								}()
+							})),
+					$elm$core$Platform$Cmd$none);
+			case 'DayChange':
+				var d = msg.a;
+				return _Utils_Tuple2(
+					$author$project$Model$Model(
+						_Utils_update(
+							m,
+							{
+								momentInWeek: function (_v5) {
+									var momentInWeek = _v5.a;
+									return $author$project$Model$MomentInWeek(
+										_Utils_update(
+											momentInWeek,
+											{day: d}));
+								}(m.momentInWeek)
+							})),
+					$elm$core$Platform$Cmd$none);
+			case 'StopChange':
+				var x = msg.a;
+				var d = msg.b;
+				return _Utils_Tuple2(
+					$author$project$Model$Model(
 						function () {
 							if (d.$ === 'Departure') {
 								return _Utils_update(
 									m,
 									{
-										departure: $author$project$Model$NoStop(x)
+										departure: A2(
+											$author$project$Main$tryParseStop,
+											$author$project$Model$NoStop(x),
+											m.stops)
 									});
 							} else {
 								return _Utils_update(
 									m,
 									{
-										destination: $author$project$Model$NoStop(x)
+										destination: A2(
+											$author$project$Main$tryParseStop,
+											$author$project$Model$NoStop(x),
+											m.stops)
 									});
 							}
-						}());
-					var $temp$msg = $author$project$Msg$ValidateStop(d),
-						$temp$_v0 = updated_model;
-					msg = $temp$msg;
-					_v0 = $temp$_v0;
-					continue update;
-				case 'BusChange':
-					var x = msg.a;
-					var $temp$msg = $author$project$Msg$ValidateBus,
-						$temp$_v0 = $author$project$Model$Model(
+						}()),
+					$elm$core$Platform$Cmd$none);
+			case 'BusChange':
+				var x = msg.a;
+				return _Utils_Tuple2(
+					$author$project$Model$Model(
 						_Utils_update(
 							m,
 							{
-								bus: $author$project$Model$NoBus(x)
-							}));
-					msg = $temp$msg;
-					_v0 = $temp$_v0;
-					continue update;
-				case 'ReverseStops':
-					return _Utils_Tuple2(
-						$author$project$Model$Model(
-							_Utils_update(
-								m,
-								{departure: m.destination, destination: m.departure})),
-						$elm$core$Platform$Cmd$none);
-				case 'ValidateBus':
+								bus: A2(
+									$author$project$Main$tryParseBus,
+									$author$project$Model$NoBus(x),
+									m.buses)
+							})),
+					$elm$core$Platform$Cmd$none);
+			case 'ReverseStops':
+				return _Utils_Tuple2(
+					$author$project$Model$Model(
+						_Utils_update(
+							m,
+							{departure: m.destination, destination: m.departure})),
+					$elm$core$Platform$Cmd$none);
+			case 'CalcDelay':
+				return _Utils_Tuple2(
+					$author$project$Model$Model(
+						_Utils_update(
+							m,
+							{loading: $author$project$Model$Loading})),
+					$author$project$Main$requestDelays(
+						$author$project$Model$Model(m)));
+			default:
+				var res = msg.a;
+				if (res.$ === 'Ok') {
+					var _v8 = res.a;
+					var d1 = _v8.a;
+					var d2 = _v8.b;
 					return _Utils_Tuple2(
 						$author$project$Model$Model(
 							_Utils_update(
 								m,
 								{
-									bus: A2($author$project$Main$tryParseBus, m.bus, m.buses)
+									delays: $elm$core$Maybe$Just(
+										_Utils_Tuple2(
+											$author$project$Msg$delayDataToFrequencies(d1),
+											$author$project$Msg$delayDataToFrequencies(d2))),
+									loading: $author$project$Model$NotLoading
 								})),
 						$elm$core$Platform$Cmd$none);
-				case 'ValidateStop':
-					var d = msg.a;
-					return _Utils_Tuple2(
-						$author$project$Model$Model(
-							function () {
-								if (d.$ === 'Departure') {
-									return _Utils_update(
-										m,
-										{
-											departure: A2($author$project$Main$tryParseStop, m.departure, m.stops)
-										});
-								} else {
-									return _Utils_update(
-										m,
-										{
-											destination: A2($author$project$Main$tryParseStop, m.destination, m.stops)
-										});
-								}
-							}()),
-						$elm$core$Platform$Cmd$none);
-				case 'CalcDelay':
+				} else {
 					return _Utils_Tuple2(
 						$author$project$Model$Model(
 							_Utils_update(
 								m,
-								{loading: $author$project$Model$Loading})),
-						$author$project$Main$requestDelays(
-							$author$project$Model$Model(m)));
-				default:
-					var res = msg.a;
-					if (res.$ === 'Ok') {
-						var _v9 = res.a;
-						var d1 = _v9.a;
-						var d2 = _v9.b;
-						return _Utils_Tuple2(
-							$author$project$Model$Model(
-								_Utils_update(
-									m,
-									{
-										delays: $elm$core$Maybe$Just(
-											_Utils_Tuple2(
-												$author$project$Msg$delayDataToFrequencies(d1),
-												$author$project$Msg$delayDataToFrequencies(d2))),
-										loading: $author$project$Model$NotLoading
-									})),
-							$elm$core$Platform$Cmd$none);
-					} else {
-						return _Utils_Tuple2(
-							$author$project$Model$Model(
-								_Utils_update(
-									m,
-									{loading: $author$project$Model$NotLoading})),
-							$elm$core$Platform$Cmd$none);
-					}
-			}
+								{loading: $author$project$Model$NotLoading})),
+						$elm$core$Platform$Cmd$none);
+				}
 		}
 	});
 var $author$project$Msg$BusChange = function (a) {
@@ -11994,17 +11962,6 @@ var $author$project$Main$view = function (_v0) {
 														]));
 											},
 											$elm$core$Dict$values(m.stops)))
-									])),
-								A2(
-								$elm$html$Html$button,
-								_List_fromArray(
-									[
-										$elm$html$Html$Events$onClick(
-										$author$project$Msg$ValidateStop($author$project$Msg$Departure))
-									]),
-								_List_fromArray(
-									[
-										$elm$html$Html$text('Check')
 									]))
 							]),
 						function () {
@@ -12066,18 +12023,7 @@ var $author$project$Main$view = function (_v0) {
 											return A2($author$project$Msg$StopChange, x, $author$project$Msg$Destination);
 										})
 									]),
-								_List_Nil),
-								A2(
-								$elm$html$Html$button,
-								_List_fromArray(
-									[
-										$elm$html$Html$Events$onClick(
-										$author$project$Msg$ValidateStop($author$project$Msg$Destination))
-									]),
-								_List_fromArray(
-									[
-										$elm$html$Html$text('Check')
-									]))
+								_List_Nil)
 							]),
 						function () {
 							var _v7 = m.destination;
@@ -12148,16 +12094,6 @@ var $author$project$Main$view = function (_v0) {
 														]));
 											},
 											$elm$core$Dict$values(m.buses)))
-									])),
-								A2(
-								$elm$html$Html$button,
-								_List_fromArray(
-									[
-										$elm$html$Html$Events$onClick($author$project$Msg$ValidateBus)
-									]),
-								_List_fromArray(
-									[
-										$elm$html$Html$text('Check')
 									]))
 							]),
 						function () {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11743,442 +11743,466 @@ var $author$project$Main$view = function (_v0) {
 	return A2(
 		$elm$html$Html$div,
 		_List_Nil,
-		_List_fromArray(
-			[
-				A2(
-				$elm$html$Html$button,
-				_List_fromArray(
-					[
-						$elm$html$Html$Events$onClick(
-						$author$project$Msg$TimeChange($author$project$Msg$Minus5Min))
-					]),
-				_List_fromArray(
-					[
-						$elm$html$Html$text('-5')
-					])),
-				A2(
-				$elm$html$Html$button,
-				_List_fromArray(
-					[
-						$elm$html$Html$Events$onClick(
-						$author$project$Msg$TimeChange($author$project$Msg$Minus15Min))
-					]),
-				_List_fromArray(
-					[
-						$elm$html$Html$text('-15')
-					])),
-				A2(
-				$elm$html$Html$button,
-				_List_fromArray(
-					[
-						$elm$html$Html$Events$onClick(
-						$author$project$Msg$TimeChange($author$project$Msg$MinusHour))
-					]),
-				_List_fromArray(
-					[
-						$elm$html$Html$text('-60')
-					])),
-				$elm$html$Html$text(
-				function (_v1) {
-					var momentInWeek = _v1.a;
-					return ((momentInWeek.hour < 10) ? '0' : '') + ($elm$core$String$fromInt(momentInWeek.hour) + (':' + (((momentInWeek.minute < 10) ? '0' : '') + $elm$core$String$fromInt(momentInWeek.minute))));
-				}(m.momentInWeek)),
-				A2(
-				$elm$html$Html$button,
-				_List_fromArray(
-					[
-						$elm$html$Html$Events$onClick(
-						$author$project$Msg$TimeChange($author$project$Msg$PlusHour))
-					]),
-				_List_fromArray(
-					[
-						$elm$html$Html$text('+60')
-					])),
-				A2(
-				$elm$html$Html$button,
-				_List_fromArray(
-					[
-						$elm$html$Html$Events$onClick(
-						$author$project$Msg$TimeChange($author$project$Msg$Plus15Min))
-					]),
-				_List_fromArray(
-					[
-						$elm$html$Html$text('+15')
-					])),
-				A2(
-				$elm$html$Html$button,
-				_List_fromArray(
-					[
-						$elm$html$Html$Events$onClick(
-						$author$project$Msg$TimeChange($author$project$Msg$Plus5Min))
-					]),
-				_List_fromArray(
-					[
-						$elm$html$Html$text('+5')
-					])),
-				A2(
-				$elm$html$Html$div,
-				_List_Nil,
-				_List_fromArray(
-					[
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick(
-								$author$project$Msg$DayChange($elm$time$Time$Mon))
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Ma')
-							])),
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick(
-								$author$project$Msg$DayChange($elm$time$Time$Tue))
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Di')
-							])),
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick(
-								$author$project$Msg$DayChange($elm$time$Time$Wed))
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Wo')
-							])),
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick(
-								$author$project$Msg$DayChange($elm$time$Time$Thu))
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Do')
-							])),
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick(
-								$author$project$Msg$DayChange($elm$time$Time$Fri))
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Vr')
-							])),
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick(
-								$author$project$Msg$DayChange($elm$time$Time$Sat))
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Za')
-							])),
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick(
-								$author$project$Msg$DayChange($elm$time$Time$Sun))
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Zo')
-							])),
-						$elm$html$Html$text(
-						$author$project$Main$toDutchWeekday(
-							function (_v2) {
-								var momentInWeek = _v2.a;
-								return momentInWeek.day;
-							}(m.momentInWeek)))
-					])),
-				A2(
-				$elm$html$Html$div,
-				_List_Nil,
-				_Utils_ap(
+		_Utils_ap(
+			_List_fromArray(
+				[
+					A2(
+					$elm$html$Html$button,
+					_List_fromArray(
+						[
+							$elm$html$Html$Events$onClick(
+							$author$project$Msg$TimeChange($author$project$Msg$Minus5Min))
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text('-5')
+						])),
+					A2(
+					$elm$html$Html$button,
+					_List_fromArray(
+						[
+							$elm$html$Html$Events$onClick(
+							$author$project$Msg$TimeChange($author$project$Msg$Minus15Min))
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text('-15')
+						])),
+					A2(
+					$elm$html$Html$button,
+					_List_fromArray(
+						[
+							$elm$html$Html$Events$onClick(
+							$author$project$Msg$TimeChange($author$project$Msg$MinusHour))
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text('-60')
+						])),
+					$elm$html$Html$text(
+					function (_v1) {
+						var momentInWeek = _v1.a;
+						return ((momentInWeek.hour < 10) ? '0' : '') + ($elm$core$String$fromInt(momentInWeek.hour) + (':' + (((momentInWeek.minute < 10) ? '0' : '') + $elm$core$String$fromInt(momentInWeek.minute))));
+					}(m.momentInWeek)),
+					A2(
+					$elm$html$Html$button,
+					_List_fromArray(
+						[
+							$elm$html$Html$Events$onClick(
+							$author$project$Msg$TimeChange($author$project$Msg$PlusHour))
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text('+60')
+						])),
+					A2(
+					$elm$html$Html$button,
+					_List_fromArray(
+						[
+							$elm$html$Html$Events$onClick(
+							$author$project$Msg$TimeChange($author$project$Msg$Plus15Min))
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text('+15')
+						])),
+					A2(
+					$elm$html$Html$button,
+					_List_fromArray(
+						[
+							$elm$html$Html$Events$onClick(
+							$author$project$Msg$TimeChange($author$project$Msg$Plus5Min))
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text('+5')
+						])),
+					A2(
+					$elm$html$Html$div,
+					_List_Nil,
 					_List_fromArray(
 						[
 							A2(
-							$elm$html$Html$input,
+							$elm$html$Html$button,
 							_List_fromArray(
 								[
-									$elm$html$Html$Attributes$placeholder('Vertrekhalte'),
-									$elm$html$Html$Attributes$value(
-									function () {
-										var _v3 = m.departure;
-										if (_v3.$ === 'Stop') {
-											var i = _v3.a;
-											var f = _v3.b;
-											return f(_Utils_Tuple0);
-										} else {
-											var x = _v3.a;
-											return x;
-										}
-									}()),
-									$elm$html$Html$Attributes$list('stops'),
-									$elm$html$Html$Events$onInput(
-									function (x) {
-										return A2($author$project$Msg$StopChange, x, $author$project$Msg$Departure);
-									})
-								]),
-							_List_Nil),
-							A2(
-							$elm$html$Html$datalist,
-							_List_fromArray(
-								[
-									$elm$html$Html$Attributes$id('stops')
+									$elm$html$Html$Events$onClick(
+									$author$project$Msg$DayChange($elm$time$Time$Mon))
 								]),
 							_List_fromArray(
 								[
-									A2(
-									$elm$html$Html$select,
-									_List_Nil,
-									A2(
-										$elm$core$List$map,
-										function (_v4) {
-											var k = _v4.a;
-											var v = _v4.b;
-											return A2(
-												$elm$html$Html$option,
-												_List_Nil,
-												_List_fromArray(
-													[
-														$elm$html$Html$text(v)
-													]));
-										},
-										$elm$core$Dict$values(m.stops)))
+									$elm$html$Html$text('Ma')
 								])),
 							A2(
 							$elm$html$Html$button,
 							_List_fromArray(
 								[
 									$elm$html$Html$Events$onClick(
-									$author$project$Msg$ValidateStop($author$project$Msg$Departure))
+									$author$project$Msg$DayChange($elm$time$Time$Tue))
 								]),
 							_List_fromArray(
 								[
-									$elm$html$Html$text('Check')
-								]))
-						]),
-					function () {
-						var _v5 = m.departure;
-						if (_v5.$ === 'NoStop') {
-							var x = _v5.a;
-							return _List_Nil;
-						} else {
-							var i = _v5.a;
-							var f = _v5.b;
-							var _v6 = m.delays;
-							if (_v6.$ === 'Nothing') {
-								return _List_fromArray(
-									[
-										$elm$html$Html$text('Geldige halte')
-									]);
-							} else {
-								var _v7 = _v6.a;
-								var d1 = _v7.a;
-								var d2 = _v7.b;
-								return _List_fromArray(
-									[
-										$author$project$Main$plot(d1)
-									]);
-							}
-						}
-					}())),
-				A2(
-				$elm$html$Html$div,
-				_List_Nil,
-				_List_fromArray(
-					[
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick($author$project$Msg$ReverseStops)
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('⇅')
-							]))
-					])),
-				A2(
-				$elm$html$Html$div,
-				_List_Nil,
-				_Utils_ap(
-					_List_fromArray(
-						[
-							A2(
-							$elm$html$Html$input,
-							_List_fromArray(
-								[
-									$elm$html$Html$Attributes$placeholder('Aankomsthalte'),
-									$elm$html$Html$Attributes$list('stops'),
-									$elm$html$Html$Attributes$value(
-									function () {
-										var _v8 = m.destination;
-										if (_v8.$ === 'Stop') {
-											var i = _v8.a;
-											var f = _v8.b;
-											return f(_Utils_Tuple0);
-										} else {
-											var x = _v8.a;
-											return x;
-										}
-									}()),
-									$elm$html$Html$Events$onInput(
-									function (x) {
-										return A2($author$project$Msg$StopChange, x, $author$project$Msg$Destination);
-									})
-								]),
-							_List_Nil),
-							A2(
-							$elm$html$Html$button,
-							_List_fromArray(
-								[
-									$elm$html$Html$Events$onClick(
-									$author$project$Msg$ValidateStop($author$project$Msg$Destination))
-								]),
-							_List_fromArray(
-								[
-									$elm$html$Html$text('Check')
-								]))
-						]),
-					function () {
-						var _v9 = m.destination;
-						if (_v9.$ === 'NoStop') {
-							var x = _v9.a;
-							return _List_Nil;
-						} else {
-							var i = _v9.a;
-							var f = _v9.b;
-							var _v10 = m.delays;
-							if (_v10.$ === 'Nothing') {
-								return _List_fromArray(
-									[
-										$elm$html$Html$text('Geldige halte')
-									]);
-							} else {
-								var _v11 = _v10.a;
-								var d1 = _v11.a;
-								var d2 = _v11.b;
-								return _List_fromArray(
-									[
-										$author$project$Main$plot(d2)
-									]);
-							}
-						}
-					}())),
-				A2(
-				$elm$html$Html$div,
-				_List_Nil,
-				_Utils_ap(
-					_List_fromArray(
-						[
-							A2(
-							$elm$html$Html$input,
-							_List_fromArray(
-								[
-									$elm$html$Html$Attributes$placeholder('Bus'),
-									$elm$html$Html$Attributes$list('busses'),
-									$elm$html$Html$Attributes$value(
-									function () {
-										var _v12 = m.bus;
-										if (_v12.$ === 'Bus') {
-											var i = _v12.a;
-											var f = _v12.b;
-											return f(_Utils_Tuple0);
-										} else {
-											var x = _v12.a;
-											return x;
-										}
-									}()),
-									$elm$html$Html$Events$onInput(
-									function (x) {
-										return $author$project$Msg$BusChange(x);
-									})
-								]),
-							_List_Nil),
-							A2(
-							$elm$html$Html$datalist,
-							_List_fromArray(
-								[
-									$elm$html$Html$Attributes$id('busses')
-								]),
-							_List_fromArray(
-								[
-									A2(
-									$elm$html$Html$select,
-									_List_Nil,
-									A2(
-										$elm$core$List$map,
-										function (_v13) {
-											var k = _v13.a;
-											var v = _v13.b;
-											return A2(
-												$elm$html$Html$option,
-												_List_Nil,
-												_List_fromArray(
-													[
-														$elm$html$Html$text(v)
-													]));
-										},
-										$elm$core$Dict$values(m.buses)))
+									$elm$html$Html$text('Di')
 								])),
 							A2(
 							$elm$html$Html$button,
 							_List_fromArray(
 								[
-									$elm$html$Html$Events$onClick($author$project$Msg$ValidateBus)
+									$elm$html$Html$Events$onClick(
+									$author$project$Msg$DayChange($elm$time$Time$Wed))
 								]),
 							_List_fromArray(
 								[
-									$elm$html$Html$text('Check')
+									$elm$html$Html$text('Wo')
+								])),
+							A2(
+							$elm$html$Html$button,
+							_List_fromArray(
+								[
+									$elm$html$Html$Events$onClick(
+									$author$project$Msg$DayChange($elm$time$Time$Thu))
+								]),
+							_List_fromArray(
+								[
+									$elm$html$Html$text('Do')
+								])),
+							A2(
+							$elm$html$Html$button,
+							_List_fromArray(
+								[
+									$elm$html$Html$Events$onClick(
+									$author$project$Msg$DayChange($elm$time$Time$Fri))
+								]),
+							_List_fromArray(
+								[
+									$elm$html$Html$text('Vr')
+								])),
+							A2(
+							$elm$html$Html$button,
+							_List_fromArray(
+								[
+									$elm$html$Html$Events$onClick(
+									$author$project$Msg$DayChange($elm$time$Time$Sat))
+								]),
+							_List_fromArray(
+								[
+									$elm$html$Html$text('Za')
+								])),
+							A2(
+							$elm$html$Html$button,
+							_List_fromArray(
+								[
+									$elm$html$Html$Events$onClick(
+									$author$project$Msg$DayChange($elm$time$Time$Sun))
+								]),
+							_List_fromArray(
+								[
+									$elm$html$Html$text('Zo')
+								])),
+							$elm$html$Html$text(
+							$author$project$Main$toDutchWeekday(
+								function (_v2) {
+									var momentInWeek = _v2.a;
+									return momentInWeek.day;
+								}(m.momentInWeek)))
+						])),
+					A2(
+					$elm$html$Html$div,
+					_List_Nil,
+					_Utils_ap(
+						_List_fromArray(
+							[
+								A2(
+								$elm$html$Html$input,
+								_List_fromArray(
+									[
+										$elm$html$Html$Attributes$placeholder('Vertrekhalte'),
+										$elm$html$Html$Attributes$value(
+										function () {
+											var _v3 = m.departure;
+											if (_v3.$ === 'Stop') {
+												var i = _v3.a;
+												var f = _v3.b;
+												return f(_Utils_Tuple0);
+											} else {
+												var x = _v3.a;
+												return x;
+											}
+										}()),
+										$elm$html$Html$Attributes$list('stops'),
+										$elm$html$Html$Events$onInput(
+										function (x) {
+											return A2($author$project$Msg$StopChange, x, $author$project$Msg$Departure);
+										})
+									]),
+								_List_Nil),
+								A2(
+								$elm$html$Html$datalist,
+								_List_fromArray(
+									[
+										$elm$html$Html$Attributes$id('stops')
+									]),
+								_List_fromArray(
+									[
+										A2(
+										$elm$html$Html$select,
+										_List_Nil,
+										A2(
+											$elm$core$List$map,
+											function (_v4) {
+												var k = _v4.a;
+												var v = _v4.b;
+												return A2(
+													$elm$html$Html$option,
+													_List_Nil,
+													_List_fromArray(
+														[
+															$elm$html$Html$text(v)
+														]));
+											},
+											$elm$core$Dict$values(m.stops)))
+									])),
+								A2(
+								$elm$html$Html$button,
+								_List_fromArray(
+									[
+										$elm$html$Html$Events$onClick(
+										$author$project$Msg$ValidateStop($author$project$Msg$Departure))
+									]),
+								_List_fromArray(
+									[
+										$elm$html$Html$text('Check')
+									]))
+							]),
+						function () {
+							var _v5 = m.departure;
+							if (_v5.$ === 'NoStop') {
+								var x = _v5.a;
+								return _List_Nil;
+							} else {
+								var i = _v5.a;
+								var f = _v5.b;
+								return _List_fromArray(
+									[
+										$elm$html$Html$text('Geldige halte')
+									]);
+							}
+						}())),
+					A2(
+					$elm$html$Html$div,
+					_List_Nil,
+					_List_fromArray(
+						[
+							A2(
+							$elm$html$Html$button,
+							_List_fromArray(
+								[
+									$elm$html$Html$Events$onClick($author$project$Msg$ReverseStops)
+								]),
+							_List_fromArray(
+								[
+									$elm$html$Html$text('⇅')
 								]))
-						]),
-					function () {
-						var _v14 = m.bus;
-						if (_v14.$ === 'Bus') {
-							var i = _v14.a;
-							var f = _v14.b;
+						])),
+					A2(
+					$elm$html$Html$div,
+					_List_Nil,
+					_Utils_ap(
+						_List_fromArray(
+							[
+								A2(
+								$elm$html$Html$input,
+								_List_fromArray(
+									[
+										$elm$html$Html$Attributes$placeholder('Aankomsthalte'),
+										$elm$html$Html$Attributes$list('stops'),
+										$elm$html$Html$Attributes$value(
+										function () {
+											var _v6 = m.destination;
+											if (_v6.$ === 'Stop') {
+												var i = _v6.a;
+												var f = _v6.b;
+												return f(_Utils_Tuple0);
+											} else {
+												var x = _v6.a;
+												return x;
+											}
+										}()),
+										$elm$html$Html$Events$onInput(
+										function (x) {
+											return A2($author$project$Msg$StopChange, x, $author$project$Msg$Destination);
+										})
+									]),
+								_List_Nil),
+								A2(
+								$elm$html$Html$button,
+								_List_fromArray(
+									[
+										$elm$html$Html$Events$onClick(
+										$author$project$Msg$ValidateStop($author$project$Msg$Destination))
+									]),
+								_List_fromArray(
+									[
+										$elm$html$Html$text('Check')
+									]))
+							]),
+						function () {
+							var _v7 = m.destination;
+							if (_v7.$ === 'NoStop') {
+								var x = _v7.a;
+								return _List_Nil;
+							} else {
+								var i = _v7.a;
+								var f = _v7.b;
+								return _List_fromArray(
+									[
+										$elm$html$Html$text('Geldige halte')
+									]);
+							}
+						}())),
+					A2(
+					$elm$html$Html$div,
+					_List_Nil,
+					_Utils_ap(
+						_List_fromArray(
+							[
+								A2(
+								$elm$html$Html$input,
+								_List_fromArray(
+									[
+										$elm$html$Html$Attributes$placeholder('Bus'),
+										$elm$html$Html$Attributes$list('buses'),
+										$elm$html$Html$Attributes$value(
+										function () {
+											var _v8 = m.bus;
+											if (_v8.$ === 'Bus') {
+												var i = _v8.a;
+												var f = _v8.b;
+												return f(_Utils_Tuple0);
+											} else {
+												var x = _v8.a;
+												return x;
+											}
+										}()),
+										$elm$html$Html$Events$onInput(
+										function (x) {
+											return $author$project$Msg$BusChange(x);
+										})
+									]),
+								_List_Nil),
+								A2(
+								$elm$html$Html$datalist,
+								_List_fromArray(
+									[
+										$elm$html$Html$Attributes$id('buses')
+									]),
+								_List_fromArray(
+									[
+										A2(
+										$elm$html$Html$select,
+										_List_Nil,
+										A2(
+											$elm$core$List$map,
+											function (_v9) {
+												var k = _v9.a;
+												var v = _v9.b;
+												return A2(
+													$elm$html$Html$option,
+													_List_Nil,
+													_List_fromArray(
+														[
+															$elm$html$Html$text(v)
+														]));
+											},
+											$elm$core$Dict$values(m.buses)))
+									])),
+								A2(
+								$elm$html$Html$button,
+								_List_fromArray(
+									[
+										$elm$html$Html$Events$onClick($author$project$Msg$ValidateBus)
+									]),
+								_List_fromArray(
+									[
+										$elm$html$Html$text('Check')
+									]))
+							]),
+						function () {
+							var _v10 = m.bus;
+							if (_v10.$ === 'Bus') {
+								var i = _v10.a;
+								var f = _v10.b;
+								return _List_fromArray(
+									[
+										$elm$html$Html$text('Geldige bus')
+									]);
+							} else {
+								var x = _v10.a;
+								return _List_Nil;
+							}
+						}())),
+					A2(
+					$elm$html$Html$div,
+					_List_Nil,
+					_List_fromArray(
+						[
+							A2(
+							$elm$html$Html$button,
+							_List_fromArray(
+								[
+									$elm$html$Html$Events$onClick($author$project$Msg$CalcDelay)
+								]),
+							_List_fromArray(
+								[
+									$elm$html$Html$text('Voorspel vertraging')
+								]))
+						]))
+				]),
+			_Utils_ap(
+				function () {
+					var _v11 = m.departure;
+					if (_v11.$ === 'NoStop') {
+						var x = _v11.a;
+						return _List_Nil;
+					} else {
+						var i = _v11.a;
+						var f = _v11.b;
+						var _v12 = m.delays;
+						if (_v12.$ === 'Nothing') {
+							return _List_Nil;
+						} else {
+							var _v13 = _v12.a;
+							var d1 = _v13.a;
+							var d2 = _v13.b;
 							return _List_fromArray(
 								[
-									$elm$html$Html$text('Geldige bus')
+									$author$project$Main$plot(d1)
 								]);
-						} else {
-							var x = _v14.a;
-							return _List_Nil;
 						}
-					}())),
-				A2(
-				$elm$html$Html$div,
-				_List_Nil,
-				_List_fromArray(
-					[
-						A2(
-						$elm$html$Html$button,
-						_List_fromArray(
-							[
-								$elm$html$Html$Events$onClick($author$project$Msg$CalcDelay)
-							]),
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Voorspel vertraging')
-							]))
-					]))
-			]));
+					}
+				}(),
+				function () {
+					var _v14 = m.destination;
+					if (_v14.$ === 'NoStop') {
+						var x = _v14.a;
+						return _List_Nil;
+					} else {
+						var i = _v14.a;
+						var f = _v14.b;
+						var _v15 = m.delays;
+						if (_v15.$ === 'Nothing') {
+							return _List_Nil;
+						} else {
+							var _v16 = _v15.a;
+							var d1 = _v16.a;
+							var d2 = _v16.b;
+							return _List_fromArray(
+								[
+									$author$project$Main$plot(d2)
+								]);
+						}
+					}
+				}())));
 };
 var $author$project$Main$main = $elm$browser$Browser$element(
 	{init: $author$project$Main$init, subscriptions: $author$project$Main$subscriptions, update: $author$project$Main$update, view: $author$project$Main$view});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4622,7 +4622,44 @@ function _Url_percentDecode(string)
 	{
 		return $elm$core$Maybe$Nothing;
 	}
-}var $elm$core$Basics$EQ = {$: 'EQ'};
+}
+
+
+var _Bitwise_and = F2(function(a, b)
+{
+	return a & b;
+});
+
+var _Bitwise_or = F2(function(a, b)
+{
+	return a | b;
+});
+
+var _Bitwise_xor = F2(function(a, b)
+{
+	return a ^ b;
+});
+
+function _Bitwise_complement(a)
+{
+	return ~a;
+};
+
+var _Bitwise_shiftLeftBy = F2(function(offset, a)
+{
+	return a << offset;
+});
+
+var _Bitwise_shiftRightBy = F2(function(offset, a)
+{
+	return a >> offset;
+});
+
+var _Bitwise_shiftRightZfBy = F2(function(offset, a)
+{
+	return a >>> offset;
+});
+var $elm$core$Basics$EQ = {$: 'EQ'};
 var $elm$core$Basics$GT = {$: 'GT'};
 var $elm$core$Basics$LT = {$: 'LT'};
 var $elm$core$List$cons = _List_cons;
@@ -6337,6 +6374,14 @@ var $author$project$Main$requestBuses = A3($author$project$Main$requestStatic, '
 var $author$project$Msg$GotDelays = function (a) {
 	return {$: 'GotDelays', a: a};
 };
+var $author$project$Main$decodeFrequency = A3(
+	$elm$json$Json$Decode$map2,
+	F2(
+		function (a, b) {
+			return _Utils_Tuple2(a, b);
+		}),
+	A2($elm$json$Json$Decode$field, 'punct', $elm$json$Json$Decode$int),
+	A2($elm$json$Json$Decode$field, 'freq', $elm$json$Json$Decode$int));
 var $elm$url$Url$Builder$QueryParameter = F2(
 	function (a, b) {
 		return {$: 'QueryParameter', a: a, b: b};
@@ -6389,8 +6434,14 @@ var $author$project$Main$requestDelays = function (_v0) {
 							function (a, b) {
 								return _Utils_Tuple2(a, b);
 							}),
-						A2($elm$json$Json$Decode$field, 'departureDelay', $elm$json$Json$Decode$int),
-						A2($elm$json$Json$Decode$field, 'destinationDelay', $elm$json$Json$Decode$int))),
+						A2(
+							$elm$json$Json$Decode$field,
+							'departureDelays',
+							$elm$json$Json$Decode$list($author$project$Main$decodeFrequency)),
+						A2(
+							$elm$json$Json$Decode$field,
+							'destinationDelays',
+							$elm$json$Json$Decode$list($author$project$Main$decodeFrequency)))),
 				headers: _List_Nil,
 				method: 'GET',
 				timeout: $elm$core$Maybe$Nothing,
@@ -6810,16 +6861,13 @@ var $author$project$Main$update = F2(
 				default:
 					var res = msg.a;
 					if (res.$ === 'Ok') {
-						var _v9 = res.a;
-						var d1 = _v9.a;
-						var d2 = _v9.b;
+						var dfdis = res.a;
 						return _Utils_Tuple2(
 							$author$project$Model$Model(
 								_Utils_update(
 									m,
 									{
-										delays: $elm$core$Maybe$Just(
-											_Utils_Tuple2(d1, d2)),
+										delays: $elm$core$Maybe$Just(dfdis),
 										loading: $author$project$Model$NotLoading
 									})),
 							$elm$core$Platform$Cmd$none);
@@ -6921,9 +6969,4744 @@ var $elm$html$Html$Events$onInput = function (tagger) {
 };
 var $elm$html$Html$option = _VirtualDom_node('option');
 var $elm$html$Html$Attributes$placeholder = $elm$html$Html$Attributes$stringProperty('placeholder');
-var $elm$html$Html$select = _VirtualDom_node('select');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$AccessibilityTableNoLabels = {$: 'AccessibilityTableNoLabels'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Axis$Bottom = function (a) {
+	return {$: 'Bottom', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$ColorNone = {$: 'ColorNone'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DomainBand = function (a) {
+	return {$: 'DomainBand', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DomainContinuous = function (a) {
+	return {$: 'DomainContinuous', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DomainTime = function (a) {
+	return {$: 'DomainTime', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Axis$Left = function (a) {
+	return {$: 'Left', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Line = {$: 'Line'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$LinearScale = {$: 'LinearScale'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$NoColumnTitle = {$: 'NoColumnTitle'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$NoLabel = {$: 'NoLabel'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultHeight = 400;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$GroupedBar = {$: 'GroupedBar'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultLayout = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$GroupedBar;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultMargin = {bottom: 20, left: 30, right: 20, top: 1};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Vertical = {$: 'Vertical'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultOrientation = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Vertical;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultPadding = {bottom: 2, left: 2, right: 0, top: 0};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultWidth = 600;
+var $elm$core$String$fromFloat = _String_fromNumber;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$initialDomainBandStruct = {bandGroup: $elm$core$Maybe$Nothing, bandSingle: $elm$core$Maybe$Nothing, continuous: $elm$core$Maybe$Nothing};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$initialDomainContinuousStruct = {x: $elm$core$Maybe$Nothing, y: $elm$core$Maybe$Nothing};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$initialDomainTimeStruct = {x: $elm$core$Maybe$Nothing, y: $elm$core$Maybe$Nothing};
+var $folkertdev$one_true_path_experiment$SubPath$Empty = {$: 'Empty'};
+var $folkertdev$one_true_path_experiment$SubPath$empty = $folkertdev$one_true_path_experiment$SubPath$Empty;
+var $folkertdev$one_true_path_experiment$LowLevel$Command$LineTo = function (a) {
+	return {$: 'LineTo', a: a};
+};
+var $folkertdev$one_true_path_experiment$LowLevel$Command$lineTo = $folkertdev$one_true_path_experiment$LowLevel$Command$LineTo;
+var $folkertdev$one_true_path_experiment$LowLevel$Command$MoveTo = function (a) {
+	return {$: 'MoveTo', a: a};
+};
+var $folkertdev$one_true_path_experiment$LowLevel$Command$moveTo = $folkertdev$one_true_path_experiment$LowLevel$Command$MoveTo;
+var $folkertdev$one_true_path_experiment$SubPath$SubPath = function (a) {
+	return {$: 'SubPath', a: a};
+};
+var $folkertdev$elm_deque$Deque$Deque = function (a) {
+	return {$: 'Deque', a: a};
+};
+var $elm$core$Basics$composeL = F3(
+	function (g, f, x) {
+		return g(
+			f(x));
+	});
+var $elm$core$List$drop = F2(
+	function (n, list) {
+		drop:
+		while (true) {
+			if (n <= 0) {
+				return list;
+			} else {
+				if (!list.b) {
+					return list;
+				} else {
+					var x = list.a;
+					var xs = list.b;
+					var $temp$n = n - 1,
+						$temp$list = xs;
+					n = $temp$n;
+					list = $temp$list;
+					continue drop;
+				}
+			}
+		}
+	});
+var $elm$core$List$takeReverse = F3(
+	function (n, list, kept) {
+		takeReverse:
+		while (true) {
+			if (n <= 0) {
+				return kept;
+			} else {
+				if (!list.b) {
+					return kept;
+				} else {
+					var x = list.a;
+					var xs = list.b;
+					var $temp$n = n - 1,
+						$temp$list = xs,
+						$temp$kept = A2($elm$core$List$cons, x, kept);
+					n = $temp$n;
+					list = $temp$list;
+					kept = $temp$kept;
+					continue takeReverse;
+				}
+			}
+		}
+	});
+var $elm$core$List$takeTailRec = F2(
+	function (n, list) {
+		return $elm$core$List$reverse(
+			A3($elm$core$List$takeReverse, n, list, _List_Nil));
+	});
+var $elm$core$List$takeFast = F3(
+	function (ctr, n, list) {
+		if (n <= 0) {
+			return _List_Nil;
+		} else {
+			var _v0 = _Utils_Tuple2(n, list);
+			_v0$1:
+			while (true) {
+				_v0$5:
+				while (true) {
+					if (!_v0.b.b) {
+						return list;
+					} else {
+						if (_v0.b.b.b) {
+							switch (_v0.a) {
+								case 1:
+									break _v0$1;
+								case 2:
+									var _v2 = _v0.b;
+									var x = _v2.a;
+									var _v3 = _v2.b;
+									var y = _v3.a;
+									return _List_fromArray(
+										[x, y]);
+								case 3:
+									if (_v0.b.b.b.b) {
+										var _v4 = _v0.b;
+										var x = _v4.a;
+										var _v5 = _v4.b;
+										var y = _v5.a;
+										var _v6 = _v5.b;
+										var z = _v6.a;
+										return _List_fromArray(
+											[x, y, z]);
+									} else {
+										break _v0$5;
+									}
+								default:
+									if (_v0.b.b.b.b && _v0.b.b.b.b.b) {
+										var _v7 = _v0.b;
+										var x = _v7.a;
+										var _v8 = _v7.b;
+										var y = _v8.a;
+										var _v9 = _v8.b;
+										var z = _v9.a;
+										var _v10 = _v9.b;
+										var w = _v10.a;
+										var tl = _v10.b;
+										return (ctr > 1000) ? A2(
+											$elm$core$List$cons,
+											x,
+											A2(
+												$elm$core$List$cons,
+												y,
+												A2(
+													$elm$core$List$cons,
+													z,
+													A2(
+														$elm$core$List$cons,
+														w,
+														A2($elm$core$List$takeTailRec, n - 4, tl))))) : A2(
+											$elm$core$List$cons,
+											x,
+											A2(
+												$elm$core$List$cons,
+												y,
+												A2(
+													$elm$core$List$cons,
+													z,
+													A2(
+														$elm$core$List$cons,
+														w,
+														A3($elm$core$List$takeFast, ctr + 1, n - 4, tl)))));
+									} else {
+										break _v0$5;
+									}
+							}
+						} else {
+							if (_v0.a === 1) {
+								break _v0$1;
+							} else {
+								break _v0$5;
+							}
+						}
+					}
+				}
+				return list;
+			}
+			var _v1 = _v0.b;
+			var x = _v1.a;
+			return _List_fromArray(
+				[x]);
+		}
+	});
+var $elm$core$List$take = F2(
+	function (n, list) {
+		return A3($elm$core$List$takeFast, 0, n, list);
+	});
+var $folkertdev$elm_deque$Internal$rebalance = function (deque) {
+	var sizeF = deque.sizeF;
+	var sizeR = deque.sizeR;
+	var front = deque.front;
+	var rear = deque.rear;
+	var size1 = ((sizeF + sizeR) / 2) | 0;
+	var size2 = (sizeF + sizeR) - size1;
+	var balanceConstant = 4;
+	if ((sizeF + sizeR) < 2) {
+		return deque;
+	} else {
+		if (_Utils_cmp(sizeF, (balanceConstant * sizeR) + 1) > 0) {
+			var newRear = _Utils_ap(
+				rear,
+				$elm$core$List$reverse(
+					A2($elm$core$List$drop, size1, front)));
+			var newFront = A2($elm$core$List$take, size1, front);
+			return {front: newFront, rear: newRear, sizeF: size1, sizeR: size2};
+		} else {
+			if (_Utils_cmp(sizeR, (balanceConstant * sizeF) + 1) > 0) {
+				var newRear = A2($elm$core$List$take, size1, rear);
+				var newFront = _Utils_ap(
+					front,
+					$elm$core$List$reverse(
+						A2($elm$core$List$drop, size1, rear)));
+				return {front: newFront, rear: newRear, sizeF: size1, sizeR: size2};
+			} else {
+				return deque;
+			}
+		}
+	}
+};
+var $folkertdev$elm_deque$Internal$fromList = function (list) {
+	return $folkertdev$elm_deque$Internal$rebalance(
+		{
+			front: list,
+			rear: _List_Nil,
+			sizeF: $elm$core$List$length(list),
+			sizeR: 0
+		});
+};
+var $folkertdev$elm_deque$Deque$fromList = A2($elm$core$Basics$composeL, $folkertdev$elm_deque$Deque$Deque, $folkertdev$elm_deque$Internal$fromList);
+var $folkertdev$one_true_path_experiment$SubPath$with = F2(
+	function (moveto, drawtos) {
+		return $folkertdev$one_true_path_experiment$SubPath$SubPath(
+			{
+				drawtos: $folkertdev$elm_deque$Deque$fromList(drawtos),
+				moveto: moveto
+			});
+	});
+var $folkertdev$one_true_path_experiment$Curve$linear = function (points) {
+	if (!points.b) {
+		return $folkertdev$one_true_path_experiment$SubPath$empty;
+	} else {
+		var x = points.a;
+		var xs = points.b;
+		return A2(
+			$folkertdev$one_true_path_experiment$SubPath$with,
+			$folkertdev$one_true_path_experiment$LowLevel$Command$moveTo(x),
+			_List_fromArray(
+				[
+					$folkertdev$one_true_path_experiment$LowLevel$Command$lineTo(xs)
+				]));
+	}
+};
+var $gampleman$elm_visualization$Shape$linearCurve = $folkertdev$one_true_path_experiment$Curve$linear;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Config = function (a) {
+	return {$: 'Config', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig = function (config) {
+	return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Config(config);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultConfig = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
+	{
+		accessibilityContent: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$AccessibilityTableNoLabels,
+		annotations: _List_Nil,
+		axisXBand: $data_viz_lab$elm_chart_builder$Chart$Internal$Axis$Bottom(_List_Nil),
+		axisXContinuous: $data_viz_lab$elm_chart_builder$Chart$Internal$Axis$Bottom(_List_Nil),
+		axisXTime: $data_viz_lab$elm_chart_builder$Chart$Internal$Axis$Bottom(_List_Nil),
+		axisYContinuous: $data_viz_lab$elm_chart_builder$Chart$Internal$Axis$Left(_List_Nil),
+		colorResource: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$ColorNone,
+		coreStyle: _List_Nil,
+		coreStyleFromPointBandX: $elm$core$Basics$always(_List_Nil),
+		curve: function (d) {
+			return $gampleman$elm_visualization$Shape$linearCurve(d);
+		},
+		domainBand: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DomainBand($data_viz_lab$elm_chart_builder$Chart$Internal$Type$initialDomainBandStruct),
+		domainContinuous: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DomainContinuous($data_viz_lab$elm_chart_builder$Chart$Internal$Type$initialDomainContinuousStruct),
+		domainTime: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DomainTime($data_viz_lab$elm_chart_builder$Chart$Internal$Type$initialDomainTimeStruct),
+		events: _List_Nil,
+		height: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultHeight,
+		histogramDomain: $elm$core$Maybe$Nothing,
+		layout: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultLayout,
+		lineDraw: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Line,
+		margin: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultMargin,
+		orientation: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultOrientation,
+		padding: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultPadding,
+		showColumnTitle: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$NoColumnTitle,
+		showDataPoints: false,
+		showGroupLabels: false,
+		showLabels: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$NoLabel,
+		showXAxis: true,
+		showYAxis: true,
+		svgDesc: '',
+		svgTitle: '',
+		symbols: _List_Nil,
+		tableFloatFormat: $elm$core$String$fromFloat,
+		tablePosixFormat: A2($elm$core$Basics$composeR, $elm$time$Time$posixToMillis, $elm$core$String$fromInt),
+		width: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultWidth,
+		yScale: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$LinearScale,
+		zone: $elm$time$Time$utc
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$setDimensions = F2(
+	function (_v0, _v1) {
+		var margin = _v0.margin;
+		var width = _v0.width;
+		var height = _v0.height;
+		var c = _v1.a;
+		var top = margin.top + c.padding.top;
+		var right = margin.right + c.padding.right;
+		var left = margin.left + c.padding.left;
+		var bottom = margin.bottom + c.padding.bottom;
+		return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
+			_Utils_update(
+				c,
+				{height: (height - top) - bottom, margin: margin, width: (width - left) - right}));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Bar$init = function (c) {
+	return A2(
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$setDimensions,
+		{height: c.height, margin: c.margin, width: c.width},
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$defaultConfig);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DataBand = function (a) {
+	return {$: 'DataBand', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromExternalData = function (_v0) {
+	var data = _v0.a;
+	return data;
+};
+var $elm_community$list_extra$List$Extra$groupWhile = F2(
+	function (isSameGroup, items) {
+		return A3(
+			$elm$core$List$foldr,
+			F2(
+				function (x, acc) {
+					if (!acc.b) {
+						return _List_fromArray(
+							[
+								_Utils_Tuple2(x, _List_Nil)
+							]);
+					} else {
+						var _v1 = acc.a;
+						var y = _v1.a;
+						var restOfGroup = _v1.b;
+						var groups = acc.b;
+						return A2(isSameGroup, x, y) ? A2(
+							$elm$core$List$cons,
+							_Utils_Tuple2(
+								x,
+								A2($elm$core$List$cons, y, restOfGroup)),
+							groups) : A2(
+							$elm$core$List$cons,
+							_Utils_Tuple2(x, _List_Nil),
+							acc);
+					}
+				}),
+			_List_Nil,
+			items);
+	});
+var $elm$core$Tuple$second = function (_v0) {
+	var y = _v0.b;
+	return y;
+};
+var $elm$core$List$sortWith = _List_sortWith;
+var $elm$core$String$toFloat = _String_toFloat;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$sortStrings = F2(
+	function (accessor, strings) {
+		return A2(
+			$elm$core$List$sortWith,
+			F2(
+				function (a_, b_) {
+					var b = accessor(b_);
+					var a = accessor(a_);
+					var _v0 = _Utils_Tuple2(
+						$elm$core$String$toFloat(a),
+						$elm$core$String$toFloat(b));
+					if ((_v0.a.$ === 'Just') && (_v0.b.$ === 'Just')) {
+						var floatA = _v0.a.a;
+						var floatB = _v0.b.a;
+						return A2($elm$core$Basics$compare, floatA, floatB);
+					} else {
+						return A2($elm$core$Basics$compare, a, b);
+					}
+				}),
+			strings);
+	});
+var $elm$core$Maybe$withDefault = F2(
+	function (_default, maybe) {
+		if (maybe.$ === 'Just') {
+			var value = maybe.a;
+			return value;
+		} else {
+			return _default;
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$externalToDataBand = F2(
+	function (externalData, accessor) {
+		var data = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromExternalData(externalData);
+		return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DataBand(
+			A2(
+				$elm$core$List$map,
+				function (d) {
+					var groupLabel = accessor.xGroup(d.a);
+					var firstPoint = function (p) {
+						return _Utils_Tuple2(
+							accessor.xValue(p),
+							accessor.yValue(p));
+					}(d.a);
+					var points = A2(
+						$elm$core$List$cons,
+						firstPoint,
+						A2(
+							$elm$core$List$map,
+							function (p) {
+								return _Utils_Tuple2(
+									accessor.xValue(p),
+									accessor.yValue(p));
+							},
+							d.b));
+					return {groupLabel: groupLabel, points: points};
+				},
+				A2(
+					$elm_community$list_extra$List$Extra$groupWhile,
+					F2(
+						function (a, b) {
+							return _Utils_eq(
+								accessor.xGroup(a),
+								accessor.xGroup(b));
+						}),
+					A2(
+						$data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$sortStrings,
+						A2(
+							$elm$core$Basics$composeR,
+							accessor.xGroup,
+							$elm$core$Maybe$withDefault('')),
+						data))));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig = function (_v0) {
+	var config = _v0.a;
+	return config;
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$RenderChart = {$: 'RenderChart'};
+var $elm_community$typed_svg$TypedSvg$Types$Translate = F2(
+	function (a, b) {
+		return {$: 'Translate', a: a, b: b};
+	});
+var $elm$virtual_dom$VirtualDom$attribute = F2(
+	function (key, value) {
+		return A2(
+			_VirtualDom_attribute,
+			_VirtualDom_noOnOrFormAction(key),
+			_VirtualDom_noJavaScriptOrHtmlUri(value));
+	});
+var $elm$html$Html$Attributes$attribute = $elm$virtual_dom$VirtualDom$attribute;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaHidden = A2($elm$html$Html$Attributes$attribute, 'aria-hidden', 'true');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaLabelledby = function (label) {
+	return A2($elm$html$Html$Attributes$attribute, 'aria-labelledby', label);
+};
+var $elm$core$Basics$neq = _Utils_notEqual;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaLabelledbyContent = function (c) {
+	var _v0 = c.accessibilityContent;
+	if (_v0.$ === 'AccessibilityNone') {
+		return ((c.svgDesc !== '') && (c.svgTitle !== '')) ? _List_fromArray(
+			[
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaLabelledby(c.svgDesc + (' ' + c.svgTitle))
+			]) : ((c.svgDesc !== '') ? _List_fromArray(
+			[
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaLabelledby(c.svgDesc)
+			]) : ((c.svgTitle !== '') ? _List_fromArray(
+			[
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaLabelledby(c.svgTitle)
+			]) : _List_Nil));
+	} else {
+		return _List_fromArray(
+			[$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaHidden]);
+	}
+};
+var $gampleman$elm_visualization$Scale$Scale = function (a) {
+	return {$: 'Scale', a: a};
+};
+var $elm$core$Basics$clamp = F3(
+	function (low, high, number) {
+		return (_Utils_cmp(number, low) < 0) ? low : ((_Utils_cmp(number, high) > 0) ? high : number);
+	});
+var $gampleman$elm_visualization$Scale$Band$normalizeConfig = function (_v0) {
+	var paddingInner = _v0.paddingInner;
+	var paddingOuter = _v0.paddingOuter;
+	var align = _v0.align;
+	return {
+		align: A3($elm$core$Basics$clamp, 0, 1, align),
+		paddingInner: A3($elm$core$Basics$clamp, 0, 1, paddingInner),
+		paddingOuter: A3($elm$core$Basics$clamp, 0, 1, paddingOuter)
+	};
+};
+var $gampleman$elm_visualization$Scale$Band$bandwidth = F3(
+	function (cfg, domain, _v0) {
+		var d0 = _v0.a;
+		var d1 = _v0.b;
+		var n = $elm$core$List$length(domain);
+		var _v1 = (_Utils_cmp(d0, d1) < 0) ? _Utils_Tuple2(d0, d1) : _Utils_Tuple2(d1, d0);
+		var start = _v1.a;
+		var stop = _v1.b;
+		var _v2 = $gampleman$elm_visualization$Scale$Band$normalizeConfig(cfg);
+		var paddingInner = _v2.paddingInner;
+		var paddingOuter = _v2.paddingOuter;
+		var step = (stop - start) / A2($elm$core$Basics$max, 1, (n - paddingInner) + (paddingOuter * 2));
+		return step * (1 - paddingInner);
+	});
+var $gampleman$elm_visualization$Scale$Band$computePositions = F3(
+	function (cfg, n, _v0) {
+		var start = _v0.a;
+		var stop = _v0.b;
+		var _v1 = $gampleman$elm_visualization$Scale$Band$normalizeConfig(cfg);
+		var paddingInner = _v1.paddingInner;
+		var paddingOuter = _v1.paddingOuter;
+		var align = _v1.align;
+		var step = (stop - start) / A2($elm$core$Basics$max, 1, (n - paddingInner) + (paddingOuter * 2));
+		var start2 = start + (((stop - start) - (step * (n - paddingInner))) * align);
+		return _Utils_Tuple2(start2, step);
+	});
+var $gampleman$elm_visualization$Scale$Band$indexOfHelp = F3(
+	function (index, value, list) {
+		indexOfHelp:
+		while (true) {
+			if (!list.b) {
+				return $elm$core$Maybe$Nothing;
+			} else {
+				var x = list.a;
+				var xs = list.b;
+				if (_Utils_eq(value, x)) {
+					return $elm$core$Maybe$Just(index);
+				} else {
+					var $temp$index = index + 1,
+						$temp$value = value,
+						$temp$list = xs;
+					index = $temp$index;
+					value = $temp$value;
+					list = $temp$list;
+					continue indexOfHelp;
+				}
+			}
+		}
+	});
+var $gampleman$elm_visualization$Scale$Band$indexOf = $gampleman$elm_visualization$Scale$Band$indexOfHelp(0);
+var $gampleman$elm_visualization$Scale$Band$convert = F4(
+	function (cfg, domain, _v0, value) {
+		var start = _v0.a;
+		var stop = _v0.b;
+		var _v1 = A2($gampleman$elm_visualization$Scale$Band$indexOf, value, domain);
+		if (_v1.$ === 'Just') {
+			var index = _v1.a;
+			var n = $elm$core$List$length(domain);
+			if (_Utils_cmp(start, stop) < 0) {
+				var _v2 = A3(
+					$gampleman$elm_visualization$Scale$Band$computePositions,
+					cfg,
+					n,
+					_Utils_Tuple2(start, stop));
+				var start2 = _v2.a;
+				var step = _v2.b;
+				return start2 + (step * index);
+			} else {
+				var _v3 = A3(
+					$gampleman$elm_visualization$Scale$Band$computePositions,
+					cfg,
+					n,
+					_Utils_Tuple2(stop, start));
+				var stop2 = _v3.a;
+				var step = _v3.b;
+				return stop2 + (step * ((n - index) - 1));
+			}
+		} else {
+			return 0 / 0;
+		}
+	});
+var $gampleman$elm_visualization$Scale$band = F3(
+	function (config, range_, domain_) {
+		return $gampleman$elm_visualization$Scale$Scale(
+			{
+				bandwidth: A3($gampleman$elm_visualization$Scale$Band$bandwidth, config, domain_, range_),
+				convert: $gampleman$elm_visualization$Scale$Band$convert(config),
+				domain: domain_,
+				range: range_
+			});
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName = 'ecb-axis';
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisXClassName = 'ecb-axis-x';
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName = 'ecb-axis-y';
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYRightClassName = 'ecb-axis-y-right';
+var $elm$svg$Svg$Attributes$class = _VirtualDom_attribute('class');
+var $gampleman$elm_visualization$Scale$tickFormat = function (_v0) {
+	var opts = _v0.a;
+	return opts.tickFormat(opts.domain);
+};
+var $gampleman$elm_visualization$Scale$ticks = F2(
+	function (_v0, count) {
+		var scale = _v0.a;
+		return A2(scale.ticks, scale.domain, count);
+	});
+var $gampleman$elm_visualization$Axis$computeOptions = F2(
+	function (attrs, scale) {
+		var _v0 = A3(
+			$elm$core$List$foldl,
+			F2(
+				function (attr, _v1) {
+					var babyOpts = _v1.a;
+					var post = _v1.b;
+					switch (attr.$) {
+						case 'TickCount':
+							var val = attr.a;
+							return _Utils_Tuple2(
+								_Utils_update(
+									babyOpts,
+									{tickCount: val}),
+								post);
+						case 'TickSizeInner':
+							var val = attr.a;
+							return _Utils_Tuple2(
+								_Utils_update(
+									babyOpts,
+									{tickSizeInner: val}),
+								post);
+						case 'TickSizeOuter':
+							var val = attr.a;
+							return _Utils_Tuple2(
+								_Utils_update(
+									babyOpts,
+									{tickSizeOuter: val}),
+								post);
+						case 'TickPadding':
+							var val = attr.a;
+							return _Utils_Tuple2(
+								_Utils_update(
+									babyOpts,
+									{tickPadding: val}),
+								post);
+						default:
+							return _Utils_Tuple2(
+								babyOpts,
+								A2($elm$core$List$cons, attr, post));
+					}
+				}),
+			_Utils_Tuple2(
+				{tickCount: 10, tickPadding: 3, tickSizeInner: 6, tickSizeOuter: 6},
+				_List_Nil),
+			attrs);
+		var opts = _v0.a;
+		var postList = _v0.b;
+		return A3(
+			$elm$core$List$foldl,
+			F2(
+				function (attr, options) {
+					switch (attr.$) {
+						case 'Ticks':
+							var val = attr.a;
+							return _Utils_update(
+								options,
+								{ticks: val});
+						case 'TickFormat':
+							var val = attr.a;
+							return _Utils_update(
+								options,
+								{tickFormat: val});
+						default:
+							return options;
+					}
+				}),
+			{
+				tickCount: opts.tickCount,
+				tickFormat: A2($gampleman$elm_visualization$Scale$tickFormat, scale, opts.tickCount),
+				tickPadding: opts.tickPadding,
+				tickSizeInner: opts.tickSizeInner,
+				tickSizeOuter: opts.tickSizeOuter,
+				ticks: A2($gampleman$elm_visualization$Scale$ticks, scale, opts.tickCount)
+			},
+			postList);
+	});
+var $gampleman$elm_visualization$Scale$convert = F2(
+	function (_v0, value) {
+		var scale = _v0.a;
+		return A3(scale.convert, scale.domain, scale.range, value);
+	});
+var $elm$svg$Svg$Attributes$d = _VirtualDom_attribute('d');
+var $elm$svg$Svg$Attributes$dy = _VirtualDom_attribute('dy');
+var $elm$svg$Svg$Attributes$fill = _VirtualDom_attribute('fill');
+var $elm$svg$Svg$Attributes$fontFamily = _VirtualDom_attribute('font-family');
+var $elm$svg$Svg$Attributes$fontSize = _VirtualDom_attribute('font-size');
+var $elm$svg$Svg$trustedNode = _VirtualDom_nodeNS('http://www.w3.org/2000/svg');
+var $elm$svg$Svg$g = $elm$svg$Svg$trustedNode('g');
+var $elm$svg$Svg$line = $elm$svg$Svg$trustedNode('line');
+var $elm$svg$Svg$path = $elm$svg$Svg$trustedNode('path');
+var $gampleman$elm_visualization$Scale$rangeExtent = function (_v0) {
+	var options = _v0.a;
+	return A2(options.rangeExtent, options.domain, options.range);
+};
+var $elm$svg$Svg$Attributes$stroke = _VirtualDom_attribute('stroke');
 var $elm$virtual_dom$VirtualDom$text = _VirtualDom_text;
+var $elm$svg$Svg$text = $elm$virtual_dom$VirtualDom$text;
+var $elm$svg$Svg$Attributes$textAnchor = _VirtualDom_attribute('text-anchor');
+var $elm$svg$Svg$text_ = $elm$svg$Svg$trustedNode('text');
+var $elm$svg$Svg$Attributes$transform = _VirtualDom_attribute('transform');
+var $gampleman$elm_visualization$Axis$element = F4(
+	function (_v0, k, displacement, textAnchorPosition) {
+		var x = _v0.x;
+		var y = _v0.y;
+		var x2 = _v0.x2;
+		var y1 = _v0.y1;
+		var y2 = _v0.y2;
+		var translate = _v0.translate;
+		var horizontal = _v0.horizontal;
+		return F2(
+			function (attrs, scale) {
+				var rangeExtent = $gampleman$elm_visualization$Scale$rangeExtent(scale);
+				var range1 = rangeExtent.b + 0.5;
+				var range0 = rangeExtent.a + 0.5;
+				var position = $gampleman$elm_visualization$Scale$convert(scale);
+				var opts = A2($gampleman$elm_visualization$Axis$computeOptions, attrs, scale);
+				var spacing = A2($elm$core$Basics$max, opts.tickSizeInner, 0) + opts.tickPadding;
+				var drawTick = function (tick) {
+					return A2(
+						$elm$svg$Svg$g,
+						_List_fromArray(
+							[
+								$elm$svg$Svg$Attributes$class('tick'),
+								$elm$svg$Svg$Attributes$transform(
+								translate(
+									position(tick)))
+							]),
+						_List_fromArray(
+							[
+								A2(
+								$elm$svg$Svg$line,
+								_List_fromArray(
+									[
+										$elm$svg$Svg$Attributes$stroke('#000'),
+										x2(k * opts.tickSizeInner),
+										y1(0.5),
+										y2(0.5)
+									]),
+								_List_Nil),
+								A2(
+								$elm$svg$Svg$text_,
+								_List_fromArray(
+									[
+										$elm$svg$Svg$Attributes$fill('#000'),
+										x(k * spacing),
+										y(0.5),
+										$elm$svg$Svg$Attributes$dy(displacement)
+									]),
+								_List_fromArray(
+									[
+										$elm$svg$Svg$text(
+										opts.tickFormat(tick))
+									]))
+							]));
+				};
+				var domainLine = horizontal ? ('M' + ($elm$core$String$fromFloat(k * opts.tickSizeOuter) + (',' + ($elm$core$String$fromFloat(range0) + ('H0.5V' + ($elm$core$String$fromFloat(range1) + ('H' + $elm$core$String$fromFloat(k * opts.tickSizeOuter)))))))) : ('M' + ($elm$core$String$fromFloat(range0) + (',' + ($elm$core$String$fromFloat(k * opts.tickSizeOuter) + ('V0.5H' + ($elm$core$String$fromFloat(range1) + ('V' + $elm$core$String$fromFloat(k * opts.tickSizeOuter))))))));
+				return A2(
+					$elm$svg$Svg$g,
+					_List_fromArray(
+						[
+							$elm$svg$Svg$Attributes$fill('none'),
+							$elm$svg$Svg$Attributes$fontSize('10'),
+							$elm$svg$Svg$Attributes$fontFamily('sans-serif'),
+							$elm$svg$Svg$Attributes$textAnchor(textAnchorPosition)
+						]),
+					A2(
+						$elm$core$List$cons,
+						A2(
+							$elm$svg$Svg$path,
+							_List_fromArray(
+								[
+									$elm$svg$Svg$Attributes$class('domain'),
+									$elm$svg$Svg$Attributes$stroke('#000'),
+									$elm$svg$Svg$Attributes$d(domainLine)
+								]),
+							_List_Nil),
+						A2($elm$core$List$map, drawTick, opts.ticks)));
+			});
+	});
+var $elm$svg$Svg$Attributes$x = _VirtualDom_attribute('x');
+var $elm$svg$Svg$Attributes$x1 = _VirtualDom_attribute('x1');
+var $elm$svg$Svg$Attributes$x2 = _VirtualDom_attribute('x2');
+var $elm$svg$Svg$Attributes$y = _VirtualDom_attribute('y');
+var $elm$svg$Svg$Attributes$y1 = _VirtualDom_attribute('y1');
+var $elm$svg$Svg$Attributes$y2 = _VirtualDom_attribute('y2');
+var $gampleman$elm_visualization$Axis$verticalAttrs = {
+	horizontal: false,
+	translate: function (x) {
+		return 'translate(' + ($elm$core$String$fromFloat(x) + ', 0)');
+	},
+	x: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$y, $elm$core$String$fromFloat),
+	x1: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$y1, $elm$core$String$fromFloat),
+	x2: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$y2, $elm$core$String$fromFloat),
+	y: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$x, $elm$core$String$fromFloat),
+	y1: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$x1, $elm$core$String$fromFloat),
+	y2: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$x2, $elm$core$String$fromFloat)
+};
+var $gampleman$elm_visualization$Axis$bottom = A4($gampleman$elm_visualization$Axis$element, $gampleman$elm_visualization$Axis$verticalAttrs, 1, '0.71em', 'middle');
+var $elm_community$typed_svg$TypedSvg$Core$attribute = $elm$virtual_dom$VirtualDom$attribute;
+var $elm_community$typed_svg$TypedSvg$Attributes$class = function (names) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'class',
+		A2($elm$core$String$join, ' ', names));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName = 'ecb-component';
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$floorFloat = function (f) {
+	return $elm$core$Basics$floor(f);
+};
+var $elm$virtual_dom$VirtualDom$nodeNS = F2(
+	function (namespace, tag) {
+		return A2(
+			_VirtualDom_nodeNS,
+			namespace,
+			_VirtualDom_noScript(tag));
+	});
+var $elm_community$typed_svg$TypedSvg$Core$node = $elm$virtual_dom$VirtualDom$nodeNS('http://www.w3.org/2000/svg');
+var $elm_community$typed_svg$TypedSvg$g = $elm_community$typed_svg$TypedSvg$Core$node('g');
+var $gampleman$elm_visualization$Axis$horizontalAttrs = {
+	horizontal: true,
+	translate: function (y) {
+		return 'translate(0, ' + ($elm$core$String$fromFloat(y) + ')');
+	},
+	x: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$x, $elm$core$String$fromFloat),
+	x1: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$x1, $elm$core$String$fromFloat),
+	x2: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$x2, $elm$core$String$fromFloat),
+	y: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$y, $elm$core$String$fromFloat),
+	y1: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$y1, $elm$core$String$fromFloat),
+	y2: A2($elm$core$Basics$composeL, $elm$svg$Svg$Attributes$y2, $elm$core$String$fromFloat)
+};
+var $elm$core$Basics$negate = function (n) {
+	return -n;
+};
+var $gampleman$elm_visualization$Axis$left = A4($gampleman$elm_visualization$Axis$element, $gampleman$elm_visualization$Axis$horizontalAttrs, -1, '0.32em', 'end');
+var $gampleman$elm_visualization$Axis$right = A4($gampleman$elm_visualization$Axis$element, $gampleman$elm_visualization$Axis$horizontalAttrs, 1, '0.32em', 'start');
+var $gampleman$elm_visualization$Axis$TickPadding = function (a) {
+	return {$: 'TickPadding', a: a};
+};
+var $gampleman$elm_visualization$Axis$tickPadding = $gampleman$elm_visualization$Axis$TickPadding;
+var $gampleman$elm_visualization$Axis$TickSizeInner = function (a) {
+	return {$: 'TickSizeInner', a: a};
+};
+var $gampleman$elm_visualization$Axis$tickSizeInner = $gampleman$elm_visualization$Axis$TickSizeInner;
+var $gampleman$elm_visualization$Axis$TickSizeOuter = function (a) {
+	return {$: 'TickSizeOuter', a: a};
+};
+var $gampleman$elm_visualization$Axis$tickSizeOuter = $gampleman$elm_visualization$Axis$TickSizeOuter;
+var $elm$core$String$concat = function (strings) {
+	return A2($elm$core$String$join, '', strings);
+};
+var $elm_community$typed_svg$TypedSvg$TypesToStrings$transformToString = function (xform) {
+	var tr = F2(
+		function (name, args) {
+			return $elm$core$String$concat(
+				_List_fromArray(
+					[
+						name,
+						'(',
+						A2(
+						$elm$core$String$join,
+						' ',
+						A2($elm$core$List$map, $elm$core$String$fromFloat, args)),
+						')'
+					]));
+		});
+	switch (xform.$) {
+		case 'Matrix':
+			var a = xform.a;
+			var b = xform.b;
+			var c = xform.c;
+			var d = xform.d;
+			var e = xform.e;
+			var f = xform.f;
+			return A2(
+				tr,
+				'matrix',
+				_List_fromArray(
+					[a, b, c, d, e, f]));
+		case 'Rotate':
+			var a = xform.a;
+			var x = xform.b;
+			var y = xform.c;
+			return A2(
+				tr,
+				'rotate',
+				_List_fromArray(
+					[a, x, y]));
+		case 'Scale':
+			var x = xform.a;
+			var y = xform.b;
+			return A2(
+				tr,
+				'scale',
+				_List_fromArray(
+					[x, y]));
+		case 'SkewX':
+			var x = xform.a;
+			return A2(
+				tr,
+				'skewX',
+				_List_fromArray(
+					[x]));
+		case 'SkewY':
+			var y = xform.a;
+			return A2(
+				tr,
+				'skewY',
+				_List_fromArray(
+					[y]));
+		default:
+			var x = xform.a;
+			var y = xform.b;
+			return A2(
+				tr,
+				'translate',
+				_List_fromArray(
+					[x, y]));
+	}
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$transform = function (transforms) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'transform',
+		A2(
+			$elm$core$String$join,
+			' ',
+			A2($elm$core$List$map, $elm_community$typed_svg$TypedSvg$TypesToStrings$transformToString, transforms)));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$bandGroupedYAxis = F3(
+	function (c, iconOffset, continuousScale) {
+		var p = c.padding;
+		var m = c.margin;
+		if (c.showYAxis) {
+			var _v0 = _Utils_Tuple2(c.orientation, c.axisYContinuous);
+			if (_v0.a.$ === 'Vertical') {
+				switch (_v0.b.$) {
+					case 'Left':
+						var _v1 = _v0.a;
+						var attributes = _v0.b.a;
+						return _List_fromArray(
+							[
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2(
+												$elm_community$typed_svg$TypedSvg$Types$Translate,
+												$data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$floorFloat(m.left),
+												iconOffset + m.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$left, attributes, continuousScale)
+									]))
+							]);
+					case 'Right':
+						var _v2 = _v0.a;
+						var attributes = _v0.b.a;
+						return _List_fromArray(
+							[
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, (c.width + c.margin.left) + c.padding.left, iconOffset + c.margin.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$right, attributes, continuousScale)
+									]))
+							]);
+					default:
+						var _v3 = _v0.a;
+						var attributes = _v0.b.a;
+						var rightAttrs = _Utils_ap(
+							attributes,
+							_List_fromArray(
+								[
+									$gampleman$elm_visualization$Axis$tickSizeInner(c.width),
+									$gampleman$elm_visualization$Axis$tickPadding(c.margin.right + c.margin.left),
+									$gampleman$elm_visualization$Axis$tickSizeOuter(0)
+								]));
+						var leftAttrs = _Utils_ap(
+							attributes,
+							_List_fromArray(
+								[
+									$gampleman$elm_visualization$Axis$tickSizeInner(0)
+								]));
+						return _List_fromArray(
+							[
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, c.margin.left - c.padding.left, iconOffset + c.margin.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$left, leftAttrs, continuousScale)
+									])),
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, c.margin.left - c.padding.left, c.margin.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYRightClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$right, rightAttrs, continuousScale)
+									]))
+							]);
+				}
+			} else {
+				switch (_v0.b.$) {
+					case 'Left':
+						var _v4 = _v0.a;
+						var attributes = _v0.b.a;
+						return _List_fromArray(
+							[
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, c.margin.left, (c.height + c.padding.bottom) + c.margin.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisXClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$bottom, attributes, continuousScale)
+									]))
+							]);
+					case 'Right':
+						var _v5 = _v0.a;
+						var attributes = _v0.b.a;
+						return _List_fromArray(
+							[
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, c.margin.left, (c.height + c.padding.bottom) + c.margin.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisXClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$bottom, attributes, continuousScale)
+									]))
+							]);
+					default:
+						var _v6 = _v0.a;
+						var attributes = _v0.b.a;
+						var topAttrs = _Utils_ap(
+							attributes,
+							_List_fromArray(
+								[
+									$gampleman$elm_visualization$Axis$tickSizeInner(c.height),
+									$gampleman$elm_visualization$Axis$tickSizeOuter(0),
+									$gampleman$elm_visualization$Axis$tickPadding(c.margin.top + c.margin.bottom)
+								]));
+						var bottomAttrs = _Utils_ap(
+							attributes,
+							_List_fromArray(
+								[
+									$gampleman$elm_visualization$Axis$tickSizeInner(0)
+								]));
+						return _List_fromArray(
+							[
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, c.margin.left, (c.height + c.padding.bottom) + c.margin.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisXClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$bottom, bottomAttrs, continuousScale)
+									])),
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, c.margin.left, c.margin.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYRightClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								_List_fromArray(
+									[
+										A2($gampleman$elm_visualization$Axis$bottom, topAttrs, continuousScale)
+									]))
+							]);
+				}
+			}
+		} else {
+			return _List_Nil;
+		}
+	});
+var $gampleman$elm_visualization$Scale$toRenderable = F2(
+	function (toString, _v0) {
+		var scale = _v0.a;
+		return $gampleman$elm_visualization$Scale$Scale(
+			{
+				convert: F3(
+					function (dmn, rng, value) {
+						return A3(scale.convert, dmn, rng, value) + (A2($elm$core$Basics$max, scale.bandwidth - 1, 0) / 2);
+					}),
+				domain: scale.domain,
+				range: scale.range,
+				rangeExtent: F2(
+					function (_v1, rng) {
+						return rng;
+					}),
+				tickFormat: F2(
+					function (_v2, _v3) {
+						return toString;
+					}),
+				ticks: F2(
+					function (dmn, _v4) {
+						return dmn;
+					})
+			});
+	});
+var $gampleman$elm_visualization$Axis$top = A4($gampleman$elm_visualization$Axis$element, $gampleman$elm_visualization$Axis$verticalAttrs, -1, '0em', 'middle');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$bandXAxis = F2(
+	function (c, bandScale) {
+		var p = c.padding;
+		var m = c.margin;
+		if (c.showXAxis) {
+			var _v0 = _Utils_Tuple2(c.orientation, c.axisXBand);
+			if (_v0.a.$ === 'Vertical') {
+				if (_v0.b.$ === 'Bottom') {
+					var _v1 = _v0.a;
+					var attributes = _v0.b.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, m.left + p.left, ((m.top + p.top) + c.height) + p.bottom)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisXClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+								]),
+							_List_fromArray(
+								[
+									A2(
+									$gampleman$elm_visualization$Axis$bottom,
+									attributes,
+									A2($gampleman$elm_visualization$Scale$toRenderable, $elm$core$Basics$identity, bandScale))
+								]))
+						]);
+				} else {
+					var _v2 = _v0.a;
+					var attributes = _v0.b.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, m.left + p.left, m.top)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisXClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+								]),
+							_List_fromArray(
+								[
+									A2(
+									$gampleman$elm_visualization$Axis$top,
+									attributes,
+									A2($gampleman$elm_visualization$Scale$toRenderable, $elm$core$Basics$identity, bandScale))
+								]))
+						]);
+				}
+			} else {
+				if (_v0.b.$ === 'Bottom') {
+					var _v3 = _v0.a;
+					var attributes = _v0.b.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, m.left - p.left, m.top)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+								]),
+							_List_fromArray(
+								[
+									A2(
+									$gampleman$elm_visualization$Axis$left,
+									attributes,
+									A2($gampleman$elm_visualization$Scale$toRenderable, $elm$core$Basics$identity, bandScale))
+								]))
+						]);
+				} else {
+					var _v4 = _v0.a;
+					var attributes = _v0.b.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, m.left - p.left, m.top)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$axisYClassName, $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+								]),
+							_List_fromArray(
+								[
+									A2(
+									$gampleman$elm_visualization$Axis$right,
+									attributes,
+									A2($gampleman$elm_visualization$Scale$toRenderable, $elm$core$Basics$identity, bandScale))
+								]))
+						]);
+				}
+			}
+		} else {
+			return _List_Nil;
+		}
+	});
+var $gampleman$elm_visualization$Scale$bandwidth = function (_v0) {
+	var scale = _v0.a;
+	return scale.bandwidth;
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$barClassName = 'ecb-bar';
+var $elm$core$Basics$min = F2(
+	function (x, y) {
+		return (_Utils_cmp(x, y) < 0) ? x : y;
+	});
+var $gampleman$elm_visualization$Scale$clamp = function (_v0) {
+	var scale = _v0.a;
+	var convert_ = F3(
+		function (_v1, range_, value) {
+			var mi = _v1.a;
+			var ma = _v1.b;
+			return A3(
+				scale.convert,
+				_Utils_Tuple2(mi, ma),
+				range_,
+				A3(
+					$elm$core$Basics$clamp,
+					A2($elm$core$Basics$min, mi, ma),
+					A2($elm$core$Basics$max, mi, ma),
+					value));
+		});
+	return $gampleman$elm_visualization$Scale$Scale(
+		_Utils_update(
+			scale,
+			{convert: convert_}));
+};
+var $elm$html$Html$Attributes$class = $elm$html$Html$Attributes$stringProperty('className');
+var $elm$core$List$filter = F2(
+	function (isGood, list) {
+		return A3(
+			$elm$core$List$foldr,
+			F2(
+				function (x, xs) {
+					return isGood(x) ? A2($elm$core$List$cons, x, xs) : xs;
+				}),
+			_List_Nil,
+			list);
+	});
+var $elm$html$Html$Attributes$classList = function (classes) {
+	return $elm$html$Html$Attributes$class(
+		A2(
+			$elm$core$String$join,
+			' ',
+			A2(
+				$elm$core$List$map,
+				$elm$core$Tuple$first,
+				A2($elm$core$List$filter, $elm$core$Tuple$second, classes))));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName = 'ecb-column';
+var $elm_community$typed_svg$TypedSvg$Types$RenderCrispEdges = {$: 'RenderCrispEdges'};
+var $elm$core$List$head = function (list) {
+	if (list.b) {
+		var x = list.a;
+		var xs = list.b;
+		return $elm$core$Maybe$Just(x);
+	} else {
+		return $elm$core$Maybe$Nothing;
+	}
+};
+var $elm$core$Basics$round = _Basics_round;
+var $avh4$elm_color$Color$toCssString = function (_v0) {
+	var r = _v0.a;
+	var g = _v0.b;
+	var b = _v0.c;
+	var a = _v0.d;
+	var roundTo = function (x) {
+		return $elm$core$Basics$round(x * 1000) / 1000;
+	};
+	var pct = function (x) {
+		return $elm$core$Basics$round(x * 10000) / 100;
+	};
+	return $elm$core$String$concat(
+		_List_fromArray(
+			[
+				'rgba(',
+				$elm$core$String$fromFloat(
+				pct(r)),
+				'%,',
+				$elm$core$String$fromFloat(
+				pct(g)),
+				'%,',
+				$elm$core$String$fromFloat(
+				pct(b)),
+				'%,',
+				$elm$core$String$fromFloat(
+				roundTo(a)),
+				')'
+			]));
+};
+var $avh4$elm_color$Color$RgbaSpace = F4(
+	function (a, b, c, d) {
+		return {$: 'RgbaSpace', a: a, b: b, c: c, d: d};
+	});
+var $avh4$elm_color$Color$white = A4($avh4$elm_color$Color$RgbaSpace, 255 / 255, 255 / 255, 255 / 255, 1.0);
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$colorPaletteToColor = F2(
+	function (palette, idx) {
+		var moduleIndex = A2(
+			$elm$core$Basics$modBy,
+			$elm$core$List$length(palette),
+			idx);
+		return $avh4$elm_color$Color$toCssString(
+			A2(
+				$elm$core$Maybe$withDefault,
+				$avh4$elm_color$Color$white,
+				$elm$core$List$head(
+					A2($elm$core$List$drop, moduleIndex, palette))));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$colorStyle = F3(
+	function (c, idx, interpolatorInput) {
+		var _v0 = _Utils_Tuple3(c.colorResource, idx, interpolatorInput);
+		_v0$3:
+		while (true) {
+			switch (_v0.a.$) {
+				case 'ColorPalette':
+					if (_v0.b.$ === 'Just') {
+						var colors = _v0.a.a;
+						var i = _v0.b.a;
+						return 'fill: ' + (A2($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$colorPaletteToColor, colors, i) + (';stroke: ' + A2($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$colorPaletteToColor, colors, i)));
+					} else {
+						break _v0$3;
+					}
+				case 'ColorInterpolator':
+					if (_v0.c.$ === 'Just') {
+						var interpolator = _v0.a.a;
+						var i = _v0.c.a;
+						return 'fill: ' + ($avh4$elm_color$Color$toCssString(
+							interpolator(i)) + (';stroke: ' + $avh4$elm_color$Color$toCssString(
+							interpolator(i))));
+					} else {
+						break _v0$3;
+					}
+				case 'Color':
+					if ((_v0.b.$ === 'Nothing') && (_v0.c.$ === 'Nothing')) {
+						var color = _v0.a.a;
+						var _v1 = _v0.b;
+						var _v2 = _v0.c;
+						return 'fill: ' + ($avh4$elm_color$Color$toCssString(color) + (';stroke: ' + $avh4$elm_color$Color$toCssString(color)));
+					} else {
+						break _v0$3;
+					}
+				default:
+					break _v0$3;
+			}
+		}
+		return 'stroke:grey';
+	});
+var $elm_community$typed_svg$TypedSvg$Core$text = $elm$virtual_dom$VirtualDom$text;
+var $elm_community$typed_svg$TypedSvg$title = $elm_community$typed_svg$TypedSvg$Core$node('title');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$columnTitleText = F2(
+	function (config, point) {
+		var _v0 = point;
+		var xVal = _v0.a;
+		var yVal = _v0.b;
+		var _v1 = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).showColumnTitle;
+		switch (_v1.$) {
+			case 'YColumnTitle':
+				var formatter = _v1.a;
+				return _List_fromArray(
+					[
+						A2(
+						$elm_community$typed_svg$TypedSvg$title,
+						_List_Nil,
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(
+								formatter(yVal))
+							]))
+					]);
+			case 'XOrdinalColumnTitle':
+				return _List_fromArray(
+					[
+						A2(
+						$elm_community$typed_svg$TypedSvg$title,
+						_List_Nil,
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(xVal)
+							]))
+					]);
+			default:
+				return _List_Nil;
+		}
+	});
+var $elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString = function (length) {
+	switch (length.$) {
+		case 'Cm':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'cm';
+		case 'Em':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'em';
+		case 'Ex':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'ex';
+		case 'In':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'in';
+		case 'Mm':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'mm';
+		case 'Num':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x);
+		case 'Pc':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'pc';
+		case 'Percent':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + '%';
+		case 'Pt':
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'pt';
+		default:
+			var x = length.a;
+			return $elm$core$String$fromFloat(x) + 'px';
+	}
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$height = function (length) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'height',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString(length));
+};
+var $elm_community$typed_svg$TypedSvg$Types$Px = function (a) {
+	return {$: 'Px', a: a};
+};
+var $elm_community$typed_svg$TypedSvg$Types$px = $elm_community$typed_svg$TypedSvg$Types$Px;
+var $elm_community$typed_svg$TypedSvg$Attributes$InPx$height = function (value) {
+	return $elm_community$typed_svg$TypedSvg$Attributes$height(
+		$elm_community$typed_svg$TypedSvg$Types$px(value));
+};
+var $elm_community$typed_svg$TypedSvg$Types$AnchorStart = {$: 'AnchorStart'};
+var $elm_community$typed_svg$TypedSvg$Types$DominantBaselineMiddle = {$: 'DominantBaselineMiddle'};
+var $elm_community$typed_svg$TypedSvg$TypesToStrings$dominantBaselineToString = function (dominantBaseline) {
+	switch (dominantBaseline.$) {
+		case 'DominantBaselineAuto':
+			return 'auto';
+		case 'DominantBaselineUseScript':
+			return 'use-script';
+		case 'DominantBaselineNoChange':
+			return 'no-change';
+		case 'DominantBaselineResetSize':
+			return 'reset-size';
+		case 'DominantBaselineIdeographic':
+			return 'ideographic';
+		case 'DominantBaselineAlphabetic':
+			return 'alphabetic';
+		case 'DominantBaselineHanging':
+			return 'hanging';
+		case 'DominantBaselineMathematical':
+			return 'mathematical';
+		case 'DominantBaselineCentral':
+			return 'central';
+		case 'DominantBaselineMiddle':
+			return 'middle';
+		case 'DominantBaselineTextAfterEdge':
+			return 'text-after-edge';
+		case 'DominantBaselineTextBeforeEdge':
+			return 'text-before-edge';
+		default:
+			return 'inherit';
+	}
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$dominantBaseline = function (baseline) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'dominant-baseline',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$dominantBaselineToString(baseline));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$labelClassName = 'ecb-label';
+var $elm_community$typed_svg$TypedSvg$TypesToStrings$anchorAlignmentToString = function (anchorAlignment) {
+	switch (anchorAlignment.$) {
+		case 'AnchorInherit':
+			return 'inherit';
+		case 'AnchorStart':
+			return 'start';
+		case 'AnchorMiddle':
+			return 'middle';
+		default:
+			return 'end';
+	}
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$textAnchor = function (anchorAlignment) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'text-anchor',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$anchorAlignmentToString(anchorAlignment));
+};
+var $elm_community$typed_svg$TypedSvg$text_ = $elm_community$typed_svg$TypedSvg$Core$node('text');
+var $elm_community$typed_svg$TypedSvg$Attributes$x = function (length) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'x',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString(length));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$InPx$x = function (value) {
+	return $elm_community$typed_svg$TypedSvg$Attributes$x(
+		$elm_community$typed_svg$TypedSvg$Types$px(value));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$y = function (length) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'y',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString(length));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$InPx$y = function (value) {
+	return $elm_community$typed_svg$TypedSvg$Attributes$y(
+		$elm_community$typed_svg$TypedSvg$Types$px(value));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalLabel = F4(
+	function (config, xPos, yPos, point) {
+		var txt = $elm_community$typed_svg$TypedSvg$text_(
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$y(yPos),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$x(xPos),
+					$elm_community$typed_svg$TypedSvg$Attributes$textAnchor($elm_community$typed_svg$TypedSvg$Types$AnchorStart),
+					$elm_community$typed_svg$TypedSvg$Attributes$dominantBaseline($elm_community$typed_svg$TypedSvg$Types$DominantBaselineMiddle),
+					$elm_community$typed_svg$TypedSvg$Attributes$class(
+					_List_fromArray(
+						[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$labelClassName]))
+				]));
+		var _v0 = point;
+		var xVal = _v0.a;
+		var yVal = _v0.b;
+		var _v1 = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).showLabels;
+		switch (_v1.$) {
+			case 'YLabel':
+				var formatter = _v1.a;
+				return _List_fromArray(
+					[
+						txt(
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(
+								formatter(yVal))
+							]))
+					]);
+			case 'XOrdinalLabel':
+				return _List_fromArray(
+					[
+						txt(
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(xVal)
+							]))
+					]);
+			default:
+				return _List_Nil;
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$NoSymbol = {$: 'NoSymbol'};
+var $elm_community$list_extra$List$Extra$getAt = F2(
+	function (idx, xs) {
+		return (idx < 0) ? $elm$core$Maybe$Nothing : $elm$core$List$head(
+			A2($elm$core$List$drop, idx, xs));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$getSymbolByIndex = F2(
+	function (all, idx) {
+		return ($elm$core$List$length(all) > 0) ? A2(
+			$elm$core$Maybe$withDefault,
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$NoSymbol,
+			A2(
+				$elm_community$list_extra$List$Extra$getAt,
+				A2(
+					$elm$core$Basics$modBy,
+					$elm$core$List$length(all),
+					idx),
+				all)) : $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$NoSymbol;
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles = F2(
+	function (_new, existing) {
+		return A2(
+			$elm$core$String$join,
+			';',
+			A3(
+				$elm$core$List$foldl,
+				F2(
+					function (newTuple, existingStrings) {
+						var newString = newTuple.a + (':' + newTuple.b);
+						var existingString = A2($elm$core$String$join, ';', existingStrings);
+						return A2($elm$core$String$contains, newTuple.a, existingString) ? A2(
+							$elm$core$List$cons,
+							newString,
+							A2(
+								$elm$core$List$filter,
+								function (s) {
+									return function (v) {
+										return !_Utils_eq(v, newTuple.a);
+									}(
+										A2(
+											$elm$core$Maybe$withDefault,
+											'',
+											$elm$core$List$head(
+												A2($elm$core$String$split, ':', s))));
+								},
+								existingStrings)) : A2($elm$core$List$cons, newString, existingStrings);
+					}),
+				A2($elm$core$String$split, ';', existing),
+				_new));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showIcons = function (_v0) {
+	var c = _v0.a;
+	return function (l) {
+		return l > 0;
+	}(
+		$elm$core$List$length(c.symbols));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$style = function (value) {
+	return A2($elm_community$typed_svg$TypedSvg$Core$attribute, 'style', value);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName = 'ecb-symbol';
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap = 2.0;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolToId = function (symbol) {
+	switch (symbol.$) {
+		case 'Circle':
+			var identifier = symbol.a.identifier;
+			return identifier;
+		case 'Custom':
+			var identifier = symbol.a.identifier;
+			return identifier;
+		case 'Corner':
+			var identifier = symbol.a.identifier;
+			return identifier;
+		case 'Triangle':
+			var identifier = symbol.a.identifier;
+			return identifier;
+		default:
+			return '';
+	}
+};
+var $elm_community$typed_svg$TypedSvg$use = $elm_community$typed_svg$TypedSvg$Core$node('use');
+var $elm$virtual_dom$VirtualDom$attributeNS = F3(
+	function (namespace, key, value) {
+		return A3(
+			_VirtualDom_attributeNS,
+			namespace,
+			_VirtualDom_noOnOrFormAction(key),
+			_VirtualDom_noJavaScriptOrHtmlUri(value));
+	});
+var $elm_community$typed_svg$TypedSvg$Core$attributeNS = $elm$virtual_dom$VirtualDom$attributeNS;
+var $elm_community$typed_svg$TypedSvg$Attributes$xlinkHref = A2($elm_community$typed_svg$TypedSvg$Core$attributeNS, 'http://www.w3.org/1999/xlink', 'xlink:href');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalSymbol = F2(
+	function (config, _v0) {
+		var idx = _v0.idx;
+		var w = _v0.w;
+		var y_ = _v0.y_;
+		var styleStr = _v0.styleStr;
+		var symbol = A2(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$getSymbolByIndex,
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).symbols,
+			idx);
+		var symbolRef = _List_fromArray(
+			[
+				A2(
+				$elm_community$typed_svg$TypedSvg$use,
+				_List_fromArray(
+					[
+						$elm_community$typed_svg$TypedSvg$Attributes$xlinkHref(
+						'#' + $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolToId(symbol))
+					]),
+				_List_Nil)
+			]);
+		var st = function (styles) {
+			return $elm_community$typed_svg$TypedSvg$Attributes$style(
+				A2($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles, styles, styleStr));
+		};
+		if ($data_viz_lab$elm_chart_builder$Chart$Internal$Type$showIcons(config)) {
+			switch (symbol.$) {
+				case 'Triangle':
+					var c = symbol.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, w + $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap, y_)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				case 'Circle':
+					var c = symbol.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, w + $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap, y_)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				case 'Corner':
+					var c = symbol.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, w + $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap, y_)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				case 'Custom':
+					var c = symbol.a;
+					var gap = c.useGap ? $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap : 0;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, w + gap, y_)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				default:
+					return _List_Nil;
+			}
+		} else {
+			return _List_Nil;
+		}
+	});
+var $elm$core$List$isEmpty = function (xs) {
+	if (!xs.b) {
+		return true;
+	} else {
+		return false;
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$labelGap = 2;
+var $elm_community$typed_svg$TypedSvg$rect = $elm_community$typed_svg$TypedSvg$Core$node('rect');
+var $elm_community$typed_svg$TypedSvg$TypesToStrings$shapeRenderingToString = function (shapeRendering) {
+	switch (shapeRendering.$) {
+		case 'RenderAuto':
+			return 'auto';
+		case 'RenderOptimizeSpeed':
+			return 'optimizeSpeed';
+		case 'RenderCrispEdges':
+			return 'crispEdges';
+		case 'RenderGeometricPrecision':
+			return 'geometricPrecision';
+		default:
+			return 'inherit';
+	}
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$shapeRendering = function (rendering) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'shape-rendering',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$shapeRenderingToString(rendering));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$width = function (length) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'width',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString(length));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$InPx$width = function (value) {
+	return $elm_community$typed_svg$TypedSvg$Attributes$width(
+		$elm_community$typed_svg$TypedSvg$Types$px(value));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalRect = F6(
+	function (config, bandSingleScale, continuousScale, colorScale, idx, point) {
+		var h = $gampleman$elm_visualization$Scale$bandwidth(bandSingleScale);
+		var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+		var labelOffset = $elm$core$List$isEmpty(c.symbols) ? 0 : h;
+		var _v0 = point;
+		var x__ = _v0.a;
+		var y__ = _v0.b;
+		var coreStyleFromX = c.coreStyleFromPointBandX(x__);
+		var y_ = A2($gampleman$elm_visualization$Scale$convert, bandSingleScale, x__);
+		var colorStyles = A3(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$colorStyle,
+			c,
+			$elm$core$Maybe$Just(idx),
+			$elm$core$Maybe$Just(
+				A2($gampleman$elm_visualization$Scale$convert, colorScale, y__)));
+		var coreStyle = $elm_community$typed_svg$TypedSvg$Attributes$style(
+			A2(
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles,
+				coreStyleFromX,
+				A2($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles, c.coreStyle, colorStyles)));
+		var w = A2($gampleman$elm_visualization$Scale$convert, continuousScale, y__);
+		var label = A4($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalLabel, config, (w + $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$labelGap) + labelOffset, y_ + (h / 2), point);
+		var rect_ = A2(
+			$elm_community$typed_svg$TypedSvg$rect,
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$x(0),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$y(y_),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$width(w),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$height(h),
+					$elm_community$typed_svg$TypedSvg$Attributes$shapeRendering($elm_community$typed_svg$TypedSvg$Types$RenderCrispEdges),
+					coreStyle
+				]),
+			A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$columnTitleText, config, point));
+		var symbol = A2(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalSymbol,
+			config,
+			{h: h, idx: idx, styleStr: colorStyles, w: w, y_: y_});
+		return A2(
+			$elm$core$List$cons,
+			rect_,
+			_Utils_ap(symbol, label));
+	});
+var $elm_community$typed_svg$TypedSvg$Types$AnchorMiddle = {$: 'AnchorMiddle'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalLabel = F4(
+	function (config, xPos, yPos, point) {
+		var txt = $elm_community$typed_svg$TypedSvg$text_(
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$x(xPos),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$y(yPos),
+					$elm_community$typed_svg$TypedSvg$Attributes$textAnchor($elm_community$typed_svg$TypedSvg$Types$AnchorMiddle),
+					$elm_community$typed_svg$TypedSvg$Attributes$class(
+					_List_fromArray(
+						[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$labelClassName]))
+				]));
+		var _v0 = point;
+		var xVal = _v0.a;
+		var yVal = _v0.b;
+		var _v1 = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).showLabels;
+		switch (_v1.$) {
+			case 'YLabel':
+				var formatter = _v1.a;
+				return _List_fromArray(
+					[
+						txt(
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(
+								formatter(yVal))
+							]))
+					]);
+			case 'XOrdinalLabel':
+				return _List_fromArray(
+					[
+						txt(
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(xVal)
+							]))
+					]);
+			default:
+				return _List_Nil;
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$symbolCustomSpace = F3(
+	function (orientation, localDimension, conf) {
+		if (orientation.$ === 'Horizontal') {
+			var scalingFactor = localDimension / conf.viewBoxHeight;
+			return scalingFactor * conf.viewBoxWidth;
+		} else {
+			var scalingFactor = localDimension / conf.viewBoxWidth;
+			return scalingFactor * conf.viewBoxHeight;
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalSymbol = F2(
+	function (config, _v0) {
+		var idx = _v0.idx;
+		var w = _v0.w;
+		var y_ = _v0.y_;
+		var x_ = _v0.x_;
+		var styleStr = _v0.styleStr;
+		var symbol = A2(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$getSymbolByIndex,
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).symbols,
+			idx);
+		var symbolRef = _List_fromArray(
+			[
+				A2(
+				$elm_community$typed_svg$TypedSvg$use,
+				_List_fromArray(
+					[
+						$elm_community$typed_svg$TypedSvg$Attributes$xlinkHref(
+						'#' + $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolToId(symbol))
+					]),
+				_List_Nil)
+			]);
+		var st = function (styles) {
+			return $elm_community$typed_svg$TypedSvg$Attributes$style(
+				A2($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles, styles, styleStr));
+		};
+		if ($data_viz_lab$elm_chart_builder$Chart$Internal$Type$showIcons(config)) {
+			switch (symbol.$) {
+				case 'Triangle':
+					var c = symbol.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, x_, (y_ - w) - $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				case 'Circle':
+					var c = symbol.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, x_, (y_ - w) - $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				case 'Corner':
+					var c = symbol.a;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, x_, (y_ - w) - $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				case 'Custom':
+					var c = symbol.a;
+					var space = A3($data_viz_lab$elm_chart_builder$Chart$Internal$Type$symbolCustomSpace, $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Vertical, w, c);
+					var gap = c.useGap ? $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap : 0;
+					return _List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A2($elm_community$typed_svg$TypedSvg$Types$Translate, x_, (y_ - space) - gap)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$symbolClassName])),
+									st(c.styles)
+								]),
+							symbolRef)
+						]);
+				default:
+					return _List_Nil;
+			}
+		} else {
+			return _List_Nil;
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalRect = F7(
+	function (config, iconOffset, bandSingleScale, continuousScale, colorScale, idx, point) {
+		var w = $gampleman$elm_visualization$Scale$bandwidth(bandSingleScale);
+		var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+		var labelOffset = $elm$core$List$isEmpty(c.symbols) ? 0 : w;
+		var _v0 = point;
+		var x__ = _v0.a;
+		var y__ = _v0.b;
+		var coreStyleFromX = c.coreStyleFromPointBandX(x__);
+		var x_ = A2($gampleman$elm_visualization$Scale$convert, bandSingleScale, x__);
+		var colorStyles = A3(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$colorStyle,
+			c,
+			$elm$core$Maybe$Just(idx),
+			$elm$core$Maybe$Just(
+				A2($gampleman$elm_visualization$Scale$convert, colorScale, y__)));
+		var coreStyle = $elm_community$typed_svg$TypedSvg$Attributes$style(
+			A2(
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles,
+				coreStyleFromX,
+				A2($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles, c.coreStyle, colorStyles)));
+		var h = (c.height - A2($gampleman$elm_visualization$Scale$convert, continuousScale, y__)) - iconOffset;
+		var y_ = A2($gampleman$elm_visualization$Scale$convert, continuousScale, y__) + iconOffset;
+		var label = A4($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalLabel, config, x_ + (w / 2), (y_ - $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$labelGap) - labelOffset, point);
+		var rect_ = A2(
+			$elm_community$typed_svg$TypedSvg$rect,
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$x(x_),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$y(y_),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$width(w),
+					$elm_community$typed_svg$TypedSvg$Attributes$InPx$height(h),
+					$elm_community$typed_svg$TypedSvg$Attributes$shapeRendering($elm_community$typed_svg$TypedSvg$Types$RenderCrispEdges),
+					coreStyle
+				]),
+			A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$columnTitleText, config, point));
+		var symbol = A2(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalSymbol,
+			config,
+			{idx: idx, styleStr: colorStyles, w: w, x_: x_, y_: y_});
+		return A2(
+			$elm$core$List$cons,
+			rect_,
+			_Utils_ap(symbol, label));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$column = F7(
+	function (config, iconOffset, bandSingleScale, continuousScale, colorScale, idx, point) {
+		var rectangle = function () {
+			var _v0 = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).orientation;
+			if (_v0.$ === 'Vertical') {
+				return A7($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalRect, config, iconOffset, bandSingleScale, continuousScale, colorScale, idx, point);
+			} else {
+				return A6($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalRect, config, bandSingleScale, continuousScale, colorScale, idx, point);
+			}
+		}();
+		return A2(
+			$elm_community$typed_svg$TypedSvg$g,
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$class(
+					_List_fromArray(
+						[
+							$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName,
+							$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName + ('-' + $elm$core$String$fromInt(idx))
+						]))
+				]),
+			rectangle);
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$dataGroupClassName = 'ecb-data-group';
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$dataGroupTranslation = F2(
+	function (bandGroupScale, dataGroup) {
+		var _v0 = dataGroup.groupLabel;
+		if (_v0.$ === 'Nothing') {
+			return 0;
+		} else {
+			var l = _v0.a;
+			return A2($gampleman$elm_visualization$Scale$convert, bandGroupScale, l);
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$columns = F7(
+	function (config, iconOffset, bandGroupScale, bandSingleScale, continuousScale, colorScale, dataGroup) {
+		var tr = function () {
+			var _v0 = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).orientation;
+			if (_v0.$ === 'Vertical') {
+				return A2(
+					$elm_community$typed_svg$TypedSvg$Types$Translate,
+					A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$dataGroupTranslation, bandGroupScale, dataGroup),
+					0);
+			} else {
+				return A2(
+					$elm_community$typed_svg$TypedSvg$Types$Translate,
+					0,
+					A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$dataGroupTranslation, bandGroupScale, dataGroup));
+			}
+		}();
+		return A2(
+			$elm_community$typed_svg$TypedSvg$g,
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$transform(
+					_List_fromArray(
+						[tr])),
+					$elm_community$typed_svg$TypedSvg$Attributes$class(
+					_List_fromArray(
+						[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$dataGroupClassName]))
+				]),
+			A2(
+				$elm$core$List$indexedMap,
+				A5($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$column, config, iconOffset, bandSingleScale, continuousScale, colorScale),
+				dataGroup.points));
+	});
+var $gampleman$elm_visualization$Scale$defaultBandConfig = {align: 0.5, paddingInner: 0.0, paddingOuter: 0.0};
+var $elm_community$typed_svg$TypedSvg$desc = $elm_community$typed_svg$TypedSvg$Core$node('desc');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$descAndTitle = function (c) {
+	return A3(
+		$elm$core$List$foldr,
+		F2(
+			function (_v0, acc) {
+				var el = _v0.a;
+				var str = _v0.b;
+				return (str === '') ? acc : A2(
+					$elm$core$List$cons,
+					el(
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(str)
+							])),
+					acc);
+			}),
+		_List_Nil,
+		_List_fromArray(
+			[
+				_Utils_Tuple2(
+				$elm_community$typed_svg$TypedSvg$title(_List_Nil),
+				c.svgTitle),
+				_Utils_Tuple2(
+				$elm_community$typed_svg$TypedSvg$desc(_List_Nil),
+				c.svgDesc)
+			]));
+};
+var $elm$html$Html$figure = _VirtualDom_node('figure');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand = function (_v0) {
+	var d = _v0.a;
+	return d;
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getBandGroupRange = F3(
+	function (config, width, height) {
+		var orientation = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).orientation;
+		if (orientation.$ === 'Horizontal') {
+			return _Utils_Tuple2(height, 0);
+		} else {
+			return _Utils_Tuple2(0, width);
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getBandSingleRange = F2(
+	function (config, value) {
+		var orientation = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).orientation;
+		if (orientation.$ === 'Horizontal') {
+			return _Utils_Tuple2(
+				$elm$core$Basics$floor(value),
+				0);
+		} else {
+			return _Utils_Tuple2(
+				0,
+				$elm$core$Basics$floor(value));
+		}
+	});
+var $elm$core$List$maximum = function (list) {
+	if (list.b) {
+		var x = list.a;
+		var xs = list.b;
+		return $elm$core$Maybe$Just(
+			A3($elm$core$List$foldl, $elm$core$Basics$max, x, xs));
+	} else {
+		return $elm$core$Maybe$Nothing;
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$symbolSpace = F3(
+	function (orientation, bandSingleScale, symbols) {
+		var localDimension = $elm$core$Basics$floor(
+			$gampleman$elm_visualization$Scale$bandwidth(bandSingleScale));
+		return $elm$core$Basics$floor(
+			A2(
+				$elm$core$Maybe$withDefault,
+				0,
+				$elm$core$List$maximum(
+					A2(
+						$elm$core$List$map,
+						function (symbol) {
+							switch (symbol.$) {
+								case 'Circle':
+									return localDimension / 2;
+								case 'Custom':
+									var conf = symbol.a;
+									return A3($data_viz_lab$elm_chart_builder$Chart$Internal$Type$symbolCustomSpace, orientation, localDimension, conf);
+								case 'Corner':
+									return localDimension;
+								case 'Triangle':
+									return localDimension;
+								default:
+									return 0;
+							}
+						},
+						symbols))));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getContinuousRange = F5(
+	function (config, renderContext, width, height, bandScale) {
+		var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+		var layout = c.layout;
+		var orientation = c.orientation;
+		if (orientation.$ === 'Horizontal') {
+			if (layout.$ === 'GroupedBar') {
+				return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showIcons(config) ? _Utils_Tuple2(
+					0,
+					(width - $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap) - A3($data_viz_lab$elm_chart_builder$Chart$Internal$Type$symbolSpace, c.orientation, bandScale, c.symbols)) : _Utils_Tuple2(0, width);
+			} else {
+				if (renderContext.$ === 'RenderChart') {
+					return _Utils_Tuple2(width, 0);
+				} else {
+					return _Utils_Tuple2(0, width);
+				}
+			}
+		} else {
+			if (layout.$ === 'GroupedBar') {
+				return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showIcons(config) ? _Utils_Tuple2(
+					(height - $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap) - A3($data_viz_lab$elm_chart_builder$Chart$Internal$Type$symbolSpace, c.orientation, bandScale, c.symbols),
+					0) : _Utils_Tuple2(height, 0);
+			} else {
+				return _Utils_Tuple2(height, 0);
+			}
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDataBandDepth = function (data) {
+	return $elm$core$List$length(
+		A2(
+			$elm$core$Maybe$withDefault,
+			_List_Nil,
+			$elm$core$List$head(
+				A2(
+					$elm$core$List$map,
+					function ($) {
+						return $.points;
+					},
+					$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data)))));
+};
+var $elm$core$List$append = F2(
+	function (xs, ys) {
+		if (!ys.b) {
+			return xs;
+		} else {
+			return A3($elm$core$List$foldr, $elm$core$List$cons, ys, xs);
+		}
+	});
+var $elm$core$List$concat = function (lists) {
+	return A3($elm$core$List$foldr, $elm$core$List$append, _List_Nil, lists);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDomainBand = function (_v0) {
+	var d = _v0.a;
+	return d;
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDomainBand = function (config) {
+	return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDomainBand(
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).domainBand);
+};
+var $elm$core$List$any = F2(
+	function (isOkay, list) {
+		any:
+		while (true) {
+			if (!list.b) {
+				return false;
+			} else {
+				var x = list.a;
+				var xs = list.b;
+				if (isOkay(x)) {
+					return true;
+				} else {
+					var $temp$isOkay = isOkay,
+						$temp$list = xs;
+					isOkay = $temp$isOkay;
+					list = $temp$list;
+					continue any;
+				}
+			}
+		}
+	});
+var $elm$core$List$member = F2(
+	function (x, xs) {
+		return A2(
+			$elm$core$List$any,
+			function (a) {
+				return _Utils_eq(a, x);
+			},
+			xs);
+	});
+var $elm$core$List$minimum = function (list) {
+	if (list.b) {
+		var x = list.a;
+		var xs = list.b;
+		return $elm$core$Maybe$Just(
+			A3($elm$core$List$foldl, $elm$core$Basics$min, x, xs));
+	} else {
+		return $elm$core$Maybe$Nothing;
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDomainBandFromData = F2(
+	function (data, config) {
+		var domain = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDomainBand(config);
+		var d = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data);
+		var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+		return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDomainBand(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$DomainBand(
+				{
+					bandGroup: function () {
+						var _v0 = domain.bandGroup;
+						if (_v0.$ === 'Just') {
+							var bandGroup = _v0.a;
+							return $elm$core$Maybe$Just(bandGroup);
+						} else {
+							return $elm$core$Maybe$Just(
+								A2(
+									$elm$core$List$indexedMap,
+									F2(
+										function (i, g) {
+											return A2(
+												$elm$core$Maybe$withDefault,
+												$elm$core$String$fromInt(i),
+												g);
+										}),
+									A2(
+										$elm$core$List$map,
+										function ($) {
+											return $.groupLabel;
+										},
+										d)));
+						}
+					}(),
+					bandSingle: function () {
+						var _v1 = domain.bandSingle;
+						if (_v1.$ === 'Just') {
+							var bandSingle = _v1.a;
+							return $elm$core$Maybe$Just(bandSingle);
+						} else {
+							return $elm$core$Maybe$Just(
+								A3(
+									$elm$core$List$foldr,
+									F2(
+										function (x, acc) {
+											return A2($elm$core$List$member, x, acc) ? acc : A2($elm$core$List$cons, x, acc);
+										}),
+									_List_Nil,
+									A2(
+										$elm$core$List$map,
+										$elm$core$Tuple$first,
+										$elm$core$List$concat(
+											A2(
+												$elm$core$List$map,
+												function ($) {
+													return $.points;
+												},
+												d)))));
+						}
+					}(),
+					continuous: function () {
+						var _v2 = domain.continuous;
+						if (_v2.$ === 'Just') {
+							var continuous = _v2.a;
+							return $elm$core$Maybe$Just(continuous);
+						} else {
+							return $elm$core$Maybe$Just(
+								function (dd) {
+									var _v3 = c.layout;
+									if ((_v3.$ === 'StackedBar') && (_v3.a.$ === 'Diverging')) {
+										var _v4 = _v3.a;
+										return _Utils_Tuple2(
+											A2(
+												$elm$core$Maybe$withDefault,
+												0,
+												$elm$core$List$minimum(dd)),
+											A2(
+												$elm$core$Maybe$withDefault,
+												0,
+												$elm$core$List$maximum(dd)));
+									} else {
+										return _Utils_Tuple2(
+											0,
+											A2(
+												$elm$core$Maybe$withDefault,
+												0,
+												$elm$core$List$maximum(dd)));
+									}
+								}(
+									A2(
+										$elm$core$List$map,
+										$elm$core$Tuple$second,
+										$elm$core$List$concat(
+											A2(
+												$elm$core$List$map,
+												function ($) {
+													return $.points;
+												},
+												d)))));
+						}
+					}()
+				}));
+	});
+var $elm$core$Basics$isNaN = _Basics_isNaN;
+var $gampleman$elm_visualization$Scale$Continuous$normalize = F2(
+	function (a, b) {
+		var c = b - a;
+		return (!c) ? $elm$core$Basics$always(0.5) : ($elm$core$Basics$isNaN(c) ? $elm$core$Basics$always(0 / 0) : function (x) {
+			return (x - a) / c;
+		});
+	});
+var $gampleman$elm_visualization$Scale$Continuous$bimap = F3(
+	function (_v0, _v1, interpolate) {
+		var d0 = _v0.a;
+		var d1 = _v0.b;
+		var r0 = _v1.a;
+		var r1 = _v1.b;
+		var _v2 = (_Utils_cmp(d1, d0) < 0) ? _Utils_Tuple2(
+			A2($gampleman$elm_visualization$Scale$Continuous$normalize, d1, d0),
+			A2(interpolate, r1, r0)) : _Utils_Tuple2(
+			A2($gampleman$elm_visualization$Scale$Continuous$normalize, d0, d1),
+			A2(interpolate, r0, r1));
+		var de = _v2.a;
+		var re = _v2.b;
+		return A2($elm$core$Basics$composeL, re, de);
+	});
+var $gampleman$elm_visualization$Scale$Continuous$convertTransform = F4(
+	function (transform, interpolate, _v0, range) {
+		var d0 = _v0.a;
+		var d1 = _v0.b;
+		return A2(
+			$elm$core$Basics$composeR,
+			transform,
+			A3(
+				$gampleman$elm_visualization$Scale$Continuous$bimap,
+				_Utils_Tuple2(
+					transform(d0),
+					transform(d1)),
+				range,
+				interpolate));
+	});
+var $gampleman$elm_visualization$Interpolation$float = F2(
+	function (a, to) {
+		var b = to - a;
+		return function (t) {
+			return a + (b * t);
+		};
+	});
+var $gampleman$elm_visualization$Scale$Continuous$invertTransform = F4(
+	function (transform, untransform, _v0, range) {
+		var d0 = _v0.a;
+		var d1 = _v0.b;
+		return A2(
+			$elm$core$Basics$composeR,
+			A3(
+				$gampleman$elm_visualization$Scale$Continuous$bimap,
+				range,
+				_Utils_Tuple2(
+					transform(d0),
+					transform(d1)),
+				$gampleman$elm_visualization$Interpolation$float),
+			untransform);
+	});
+var $elm$core$Basics$ge = _Utils_ge;
+var $gampleman$elm_visualization$Scale$Continuous$fixPoint = F3(
+	function (maxIterations, initialInput, fn) {
+		var helper = F2(
+			function (iters, _v0) {
+				helper:
+				while (true) {
+					var a = _v0.a;
+					var b = _v0.b;
+					if (_Utils_cmp(iters + 1, maxIterations) > -1) {
+						return b;
+					} else {
+						var _v1 = fn(b);
+						var outA = _v1.a;
+						var outB = _v1.b;
+						if (_Utils_eq(outA, a)) {
+							return b;
+						} else {
+							if (!outA) {
+								return b;
+							} else {
+								var $temp$iters = iters + 1,
+									$temp$_v0 = _Utils_Tuple2(outA, outB);
+								iters = $temp$iters;
+								_v0 = $temp$_v0;
+								continue helper;
+							}
+						}
+					}
+				}
+			});
+		return A2(
+			helper,
+			1,
+			fn(initialInput));
+	});
+var $elm$core$Basics$e = _Basics_e;
+var $elm$core$Basics$sqrt = _Basics_sqrt;
+var $gampleman$elm_visualization$Scale$Continuous$e10 = $elm$core$Basics$sqrt(50);
+var $gampleman$elm_visualization$Scale$Continuous$e2 = $elm$core$Basics$sqrt(2);
+var $gampleman$elm_visualization$Scale$Continuous$e5 = $elm$core$Basics$sqrt(10);
+var $gampleman$elm_visualization$Scale$Continuous$ln10 = A2($elm$core$Basics$logBase, $elm$core$Basics$e, 10);
+var $elm$core$Basics$pow = _Basics_pow;
+var $gampleman$elm_visualization$Scale$Continuous$tickIncrement = F3(
+	function (start, stop, count) {
+		var step = (stop - start) / A2($elm$core$Basics$max, 0, count);
+		var powr = $elm$core$Basics$floor(
+			A2($elm$core$Basics$logBase, $elm$core$Basics$e, step) / $gampleman$elm_visualization$Scale$Continuous$ln10);
+		var error = step / A2($elm$core$Basics$pow, 10, powr);
+		var order = (_Utils_cmp(error, $gampleman$elm_visualization$Scale$Continuous$e10) > -1) ? 10 : ((_Utils_cmp(error, $gampleman$elm_visualization$Scale$Continuous$e5) > -1) ? 5 : ((_Utils_cmp(error, $gampleman$elm_visualization$Scale$Continuous$e2) > -1) ? 2 : 1));
+		return (powr >= 0) ? (order * A2($elm$core$Basics$pow, 10, powr)) : ((-A2($elm$core$Basics$pow, 10, -powr)) / order);
+	});
+var $gampleman$elm_visualization$Scale$Continuous$withNormalizedDomain = F2(
+	function (fn, _v0) {
+		var a = _v0.a;
+		var b = _v0.b;
+		if (_Utils_cmp(a, b) < 0) {
+			return fn(
+				_Utils_Tuple2(a, b));
+		} else {
+			var _v1 = fn(
+				_Utils_Tuple2(b, a));
+			var d = _v1.a;
+			var c = _v1.b;
+			return _Utils_Tuple2(c, d);
+		}
+	});
+var $gampleman$elm_visualization$Scale$Continuous$nice = F2(
+	function (domain, count) {
+		var computation = function (_v0) {
+			var start = _v0.a;
+			var stop = _v0.b;
+			var step = A3($gampleman$elm_visualization$Scale$Continuous$tickIncrement, start, stop, count);
+			return _Utils_Tuple2(
+				step,
+				(step > 0) ? _Utils_Tuple2(
+					$elm$core$Basics$floor(start / step) * step,
+					$elm$core$Basics$ceiling(stop / step) * step) : ((step < 0) ? _Utils_Tuple2(
+					$elm$core$Basics$ceiling(start * step) / step,
+					$elm$core$Basics$floor(stop * step) / step) : _Utils_Tuple2(start, stop)));
+		};
+		return A2(
+			$gampleman$elm_visualization$Scale$Continuous$withNormalizedDomain,
+			function (dmn) {
+				return A3($gampleman$elm_visualization$Scale$Continuous$fixPoint, 10, dmn, computation);
+			},
+			domain);
+	});
+var $elm$core$Basics$abs = function (n) {
+	return (n < 0) ? (-n) : n;
+};
+var $gampleman$elm_visualization$Scale$Continuous$exponent = function (num) {
+	var helper = F2(
+		function (soFar, x) {
+			helper:
+			while (true) {
+				if (!x) {
+					return soFar;
+				} else {
+					if (x < 1) {
+						var $temp$soFar = 1 + soFar,
+							$temp$x = x * 10;
+						soFar = $temp$soFar;
+						x = $temp$x;
+						continue helper;
+					} else {
+						return soFar;
+					}
+				}
+			}
+		});
+	return A2(helper, 0, num);
+};
+var $gampleman$elm_visualization$Scale$Continuous$precisionFixed = function (step) {
+	return A2(
+		$elm$core$Basics$max,
+		0,
+		$gampleman$elm_visualization$Scale$Continuous$exponent(
+			$elm$core$Basics$abs(step)));
+};
+var $gampleman$elm_visualization$Statistics$tickStep = F3(
+	function (start, stop, count) {
+		var step0 = $elm$core$Basics$abs(stop - start) / A2($elm$core$Basics$max, 0, count);
+		var step1 = A2(
+			$elm$core$Basics$pow,
+			10,
+			$elm$core$Basics$floor(
+				A2($elm$core$Basics$logBase, $elm$core$Basics$e, step0) / A2($elm$core$Basics$logBase, $elm$core$Basics$e, 10)));
+		var error = step0 / step1;
+		var step2 = (_Utils_cmp(
+			error,
+			$elm$core$Basics$sqrt(50)) > -1) ? (step1 * 10) : ((_Utils_cmp(
+			error,
+			$elm$core$Basics$sqrt(10)) > -1) ? (step1 * 5) : ((_Utils_cmp(
+			error,
+			$elm$core$Basics$sqrt(2)) > -1) ? (step1 * 2) : step1));
+		return (_Utils_cmp(stop, start) < 0) ? (-step2) : step2;
+	});
+var $elm$core$String$cons = _String_cons;
+var $elm$core$String$fromChar = function (_char) {
+	return A2($elm$core$String$cons, _char, '');
+};
+var $elm$core$Bitwise$and = _Bitwise_and;
+var $elm$core$Bitwise$shiftRightBy = _Bitwise_shiftRightBy;
+var $elm$core$String$repeatHelp = F3(
+	function (n, chunk, result) {
+		return (n <= 0) ? result : A3(
+			$elm$core$String$repeatHelp,
+			n >> 1,
+			_Utils_ap(chunk, chunk),
+			(!(n & 1)) ? result : _Utils_ap(result, chunk));
+	});
+var $elm$core$String$repeat = F2(
+	function (n, chunk) {
+		return A3($elm$core$String$repeatHelp, n, chunk, '');
+	});
+var $elm$core$String$padRight = F3(
+	function (n, _char, string) {
+		return _Utils_ap(
+			string,
+			A2(
+				$elm$core$String$repeat,
+				n - $elm$core$String$length(string),
+				$elm$core$String$fromChar(_char)));
+	});
+var $gampleman$elm_visualization$Scale$Continuous$toFixed = F2(
+	function (precision, value) {
+		var power_ = A2($elm$core$Basics$pow, 10, precision);
+		var pad = function (num) {
+			_v0$2:
+			while (true) {
+				if (num.b) {
+					if (num.b.b) {
+						if (!num.b.b.b) {
+							var x = num.a;
+							var _v1 = num.b;
+							var y = _v1.a;
+							return _List_fromArray(
+								[
+									x,
+									A3(
+									$elm$core$String$padRight,
+									precision,
+									_Utils_chr('0'),
+									y)
+								]);
+						} else {
+							break _v0$2;
+						}
+					} else {
+						var val = num.a;
+						return (precision > 0) ? _List_fromArray(
+							[
+								val,
+								A3(
+								$elm$core$String$padRight,
+								precision,
+								_Utils_chr('0'),
+								'')
+							]) : _List_fromArray(
+							[val]);
+					}
+				} else {
+					break _v0$2;
+				}
+			}
+			var val = num;
+			return val;
+		};
+		return A2(
+			$elm$core$String$join,
+			'.',
+			pad(
+				A2(
+					$elm$core$String$split,
+					'.',
+					$elm$core$String$fromFloat(
+						$elm$core$Basics$round(value * power_) / power_))));
+	});
+var $gampleman$elm_visualization$Scale$Continuous$tickFormat = F2(
+	function (_v0, count) {
+		var start = _v0.a;
+		var stop = _v0.b;
+		return $gampleman$elm_visualization$Scale$Continuous$toFixed(
+			$gampleman$elm_visualization$Scale$Continuous$precisionFixed(
+				A3($gampleman$elm_visualization$Statistics$tickStep, start, stop, count)));
+	});
+var $elmcraft$core_extra$Float$Extra$range = F3(
+	function (start, stop, step) {
+		if (!step) {
+			return _List_Nil;
+		} else {
+			var n = A2(
+				$elm$core$Basics$max,
+				0,
+				$elm$core$Basics$ceiling((stop - start) / step));
+			var helper = F2(
+				function (i, list) {
+					helper:
+					while (true) {
+						if (i >= 0) {
+							var $temp$i = i - 1,
+								$temp$list = A2($elm$core$List$cons, start + (step * i), list);
+							i = $temp$i;
+							list = $temp$list;
+							continue helper;
+						} else {
+							return list;
+						}
+					}
+				});
+			return A2(helper, n - 1, _List_Nil);
+		}
+	});
+var $gampleman$elm_visualization$Statistics$range = $elmcraft$core_extra$Float$Extra$range;
+var $gampleman$elm_visualization$Statistics$ticks = F3(
+	function (start, stop, count) {
+		var step = A3($gampleman$elm_visualization$Statistics$tickStep, start, stop, count);
+		var end = ($elm$core$Basics$floor(stop / step) * step) + (step / 2);
+		var beg = $elm$core$Basics$ceiling(start / step) * step;
+		return A3($gampleman$elm_visualization$Statistics$range, beg, end, step);
+	});
+var $gampleman$elm_visualization$Scale$Continuous$ticks = F2(
+	function (_v0, count) {
+		var start = _v0.a;
+		var end = _v0.b;
+		return A3($gampleman$elm_visualization$Statistics$ticks, start, end, count);
+	});
+var $gampleman$elm_visualization$Scale$Continuous$scaleWithTransform = F4(
+	function (transform, untransform, range_, domain_) {
+		return {
+			convert: A2($gampleman$elm_visualization$Scale$Continuous$convertTransform, transform, $gampleman$elm_visualization$Interpolation$float),
+			domain: domain_,
+			invert: A2($gampleman$elm_visualization$Scale$Continuous$invertTransform, transform, untransform),
+			nice: $gampleman$elm_visualization$Scale$Continuous$nice,
+			range: range_,
+			rangeExtent: F2(
+				function (_v0, r) {
+					return r;
+				}),
+			tickFormat: $gampleman$elm_visualization$Scale$Continuous$tickFormat,
+			ticks: $gampleman$elm_visualization$Scale$Continuous$ticks
+		};
+	});
+var $gampleman$elm_visualization$Scale$Continuous$linear = A2($gampleman$elm_visualization$Scale$Continuous$scaleWithTransform, $elm$core$Basics$identity, $elm$core$Basics$identity);
+var $gampleman$elm_visualization$Scale$linear = F2(
+	function (range_, domain_) {
+		return $gampleman$elm_visualization$Scale$Scale(
+			A2($gampleman$elm_visualization$Scale$Continuous$linear, range_, domain_));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$outerHeight = F3(
+	function (height, margin, padding) {
+		return (((height + margin.top) + margin.bottom) + padding.top) + padding.bottom;
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$outerWidth = F3(
+	function (width, margin, padding) {
+		return (((width + margin.left) + margin.right) + padding.left) + padding.right;
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$role = function (name) {
+	return A2($elm$html$Html$Attributes$attribute, 'role', name);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Constants$rootClassName = 'ecb';
+var $elm_community$typed_svg$TypedSvg$svg = $elm_community$typed_svg$TypedSvg$Core$node('svg');
+var $elm_community$typed_svg$TypedSvg$circle = $elm_community$typed_svg$TypedSvg$Core$node('circle');
+var $elm_community$typed_svg$TypedSvg$Attributes$cx = function (length) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'cx',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString(length));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$InPx$cx = function (value) {
+	return $elm_community$typed_svg$TypedSvg$Attributes$cx(
+		$elm_community$typed_svg$TypedSvg$Types$px(value));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$cy = function (length) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'cy',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString(length));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$InPx$cy = function (value) {
+	return $elm_community$typed_svg$TypedSvg$Attributes$cy(
+		$elm_community$typed_svg$TypedSvg$Types$px(value));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$r = function (length) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'r',
+		$elm_community$typed_svg$TypedSvg$TypesToStrings$lengthToString(length));
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$InPx$r = function (value) {
+	return $elm_community$typed_svg$TypedSvg$Attributes$r(
+		$elm_community$typed_svg$TypedSvg$Types$px(value));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$circle_ = function (size) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$circle,
+		_List_fromArray(
+			[
+				$elm_community$typed_svg$TypedSvg$Attributes$InPx$cx(size / 2),
+				$elm_community$typed_svg$TypedSvg$Attributes$InPx$cy(size / 2),
+				$elm_community$typed_svg$TypedSvg$Attributes$InPx$r(size / 2)
+			]),
+		_List_Nil);
+};
+var $elm_community$typed_svg$TypedSvg$Attributes$points = function (pts) {
+	var pointToString = function (_v0) {
+		var xx = _v0.a;
+		var yy = _v0.b;
+		return $elm$core$String$fromFloat(xx) + (', ' + $elm$core$String$fromFloat(yy));
+	};
+	return A2(
+		$elm_community$typed_svg$TypedSvg$Core$attribute,
+		'points',
+		A2(
+			$elm$core$String$join,
+			' ',
+			A2($elm$core$List$map, pointToString, pts)));
+};
+var $elm_community$typed_svg$TypedSvg$polygon = $elm_community$typed_svg$TypedSvg$Core$node('polygon');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$corner = function (size) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$polygon,
+		_List_fromArray(
+			[
+				$elm_community$typed_svg$TypedSvg$Attributes$points(
+				_List_fromArray(
+					[
+						_Utils_Tuple2(0.0, 0.0),
+						_Utils_Tuple2(size, 0.0),
+						_Utils_Tuple2(size, size)
+					]))
+			]),
+		_List_Nil);
+};
+var $elm_community$typed_svg$TypedSvg$Types$Scale = F2(
+	function (a, b) {
+		return {$: 'Scale', a: a, b: b};
+	});
+var $elm_community$typed_svg$TypedSvg$Attributes$d = $elm_community$typed_svg$TypedSvg$Core$attribute('d');
+var $elm_community$typed_svg$TypedSvg$path = $elm_community$typed_svg$TypedSvg$Core$node('path');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$custom = F2(
+	function (scaleFactor, conf) {
+		return A2(
+			$elm_community$typed_svg$TypedSvg$g,
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$transform(
+					_List_fromArray(
+						[
+							A2($elm_community$typed_svg$TypedSvg$Types$Scale, scaleFactor, scaleFactor)
+						]))
+				]),
+			A2(
+				$elm$core$List$map,
+				function (d_) {
+					return A2(
+						$elm_community$typed_svg$TypedSvg$path,
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Attributes$d(d_)
+							]),
+						_List_Nil);
+				},
+				conf.paths));
+	});
+var $elm_community$typed_svg$TypedSvg$symbol = $elm_community$typed_svg$TypedSvg$Core$node('symbol');
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$triangle = function (size) {
+	return A2(
+		$elm_community$typed_svg$TypedSvg$polygon,
+		_List_fromArray(
+			[
+				$elm_community$typed_svg$TypedSvg$Attributes$points(
+				_List_fromArray(
+					[
+						_Utils_Tuple2(size / 2, 0.0),
+						_Utils_Tuple2(size, size),
+						_Utils_Tuple2(0.0, size)
+					]))
+			]),
+		_List_Nil);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$symbolsToSymbolElements = F3(
+	function (orientation, bandSingleScale, symbols) {
+		var localDimension = $gampleman$elm_visualization$Scale$bandwidth(bandSingleScale);
+		return A2(
+			$elm$core$List$map,
+			function (symbol) {
+				var s = $elm_community$typed_svg$TypedSvg$symbol(
+					_List_fromArray(
+						[
+							$elm$html$Html$Attributes$id(
+							$data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolToId(symbol))
+						]));
+				switch (symbol.$) {
+					case 'Circle':
+						var conf = symbol.a;
+						return s(
+							_List_fromArray(
+								[
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$circle_(
+									A2($elm$core$Maybe$withDefault, localDimension, conf.size))
+								]));
+					case 'Custom':
+						var conf = symbol.a;
+						var scaleFactor = function () {
+							if (orientation.$ === 'Vertical') {
+								return localDimension / conf.viewBoxWidth;
+							} else {
+								return localDimension / conf.viewBoxHeight;
+							}
+						}();
+						return s(
+							_List_fromArray(
+								[
+									A2($data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$custom, scaleFactor, conf)
+								]));
+					case 'Corner':
+						var conf = symbol.a;
+						return s(
+							_List_fromArray(
+								[
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$corner(
+									A2($elm$core$Maybe$withDefault, localDimension, conf.size))
+								]));
+					case 'Triangle':
+						var conf = symbol.a;
+						return s(
+							_List_fromArray(
+								[
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$triangle(
+									A2($elm$core$Maybe$withDefault, localDimension, conf.size))
+								]));
+					default:
+						return s(_List_Nil);
+				}
+			},
+			symbols);
+	});
+var $elm$core$List$repeatHelp = F3(
+	function (result, n, value) {
+		repeatHelp:
+		while (true) {
+			if (n <= 0) {
+				return result;
+			} else {
+				var $temp$result = A2($elm$core$List$cons, value, result),
+					$temp$n = n - 1,
+					$temp$value = value;
+				result = $temp$result;
+				n = $temp$n;
+				value = $temp$value;
+				continue repeatHelp;
+			}
+		}
+	});
+var $elm$core$List$repeat = F2(
+	function (n, value) {
+		return A3($elm$core$List$repeatHelp, _List_Nil, n, value);
+	});
+var $elm_community$list_extra$List$Extra$rowsLength = function (listOfLists) {
+	if (!listOfLists.b) {
+		return 0;
+	} else {
+		var x = listOfLists.a;
+		return $elm$core$List$length(x);
+	}
+};
+var $elm_community$list_extra$List$Extra$transpose = function (listOfLists) {
+	return A3(
+		$elm$core$List$foldr,
+		$elm$core$List$map2($elm$core$List$cons),
+		A2(
+			$elm$core$List$repeat,
+			$elm_community$list_extra$List$Extra$rowsLength(listOfLists),
+			_List_Nil),
+		listOfLists);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$TableHelpers$dataBandToTableData = F2(
+	function (_v0, data) {
+		var tableFloatFormat = _v0.tableFloatFormat;
+		return A2(
+			$elm$core$List$map,
+			function (points) {
+				return $elm$core$List$concat(
+					A2(
+						$elm$core$List$map,
+						function (p) {
+							return _List_fromArray(
+								[
+									p.a,
+									tableFloatFormat(p.b)
+								]);
+						},
+						points));
+			},
+			$elm_community$list_extra$List$Extra$transpose(
+				A2(
+					$elm$core$List$map,
+					function ($) {
+						return $.points;
+					},
+					$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data))));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ComplexHeadings = function (a) {
+	return {$: 'ComplexHeadings', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$HeadingAndSubHeadings = F2(
+	function (a, b) {
+		return {$: 'HeadingAndSubHeadings', a: a, b: b};
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$Headings = function (a) {
+	return {$: 'Headings', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$TableHelpers$getLabelsFromContent = function (content) {
+	if (content.$ === 'AccessibilityTable') {
+		var _v1 = content.a;
+		var xLabel = _v1.a;
+		var yLabel = _v1.b;
+		return _List_fromArray(
+			[xLabel, yLabel]);
+	} else {
+		return _List_fromArray(
+			['x', 'y']);
+	}
+};
+var $elm$core$Basics$not = _Basics_not;
+var $elm$core$List$all = F2(
+	function (isOkay, list) {
+		return !A2(
+			$elm$core$List$any,
+			A2($elm$core$Basics$composeL, $elm$core$Basics$not, isOkay),
+			list);
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$noGroups = function (data) {
+	return A2(
+		$elm$core$List$all,
+		function (d) {
+			return _Utils_eq(d, $elm$core$Maybe$Nothing);
+		},
+		A2(
+			$elm$core$List$map,
+			function ($) {
+				return $.groupLabel;
+			},
+			data));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$TableHelpers$dataBandToTableHeadings = F2(
+	function (data, content) {
+		return function (dataBand) {
+			return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$noGroups(dataBand) ? A2(
+				$elm$core$Basics$always,
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Table$Headings(
+					$data_viz_lab$elm_chart_builder$Chart$Internal$TableHelpers$getLabelsFromContent(content)),
+				dataBand) : $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ComplexHeadings(
+				A2(
+					$elm$core$List$map,
+					function (d) {
+						return A2(
+							$data_viz_lab$elm_chart_builder$Chart$Internal$Table$HeadingAndSubHeadings,
+							A2($elm$core$Maybe$withDefault, '', d.groupLabel),
+							$data_viz_lab$elm_chart_builder$Chart$Internal$TableHelpers$getLabelsFromContent(content));
+					},
+					dataBand));
+		}(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$errorToString = function (error) {
+	switch (error.$) {
+		case 'NoData':
+			return 'No Data';
+		case 'RowLengthsDoNotMatch':
+			var rowNumber = error.a;
+			return 'Every line of data should be equal in length, but row ' + ($elm$core$String$fromInt(rowNumber) + ' has a different number of data points');
+		default:
+			return 'The number of column headings does not match the number of data points in each row. ';
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$Cell = function (a) {
+	return {$: 'Cell', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeading = function (a) {
+	return {$: 'ColumnHeading', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingSingle = function (a) {
+	return {$: 'ColumnHeadingSingle', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingsSimple = function (a) {
+	return {$: 'ColumnHeadingsSimple', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowHeading = function (a) {
+	return {$: 'RowHeading', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowHeadingSingle = function (a) {
+	return {$: 'RowHeadingSingle', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowHeadingsSimple = function (a) {
+	return {$: 'RowHeadingsSimple', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$TableConfiguration = function (a) {
+	return {$: 'TableConfiguration', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowLengthsDoNotMatch = function (a) {
+	return {$: 'RowLengthsDoNotMatch', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$allRowsEqualLengthHelper = F3(
+	function (rowLength, rowNumber, remainingRows) {
+		allRowsEqualLengthHelper:
+		while (true) {
+			if (!remainingRows.b) {
+				return $elm$core$Result$Ok(rowLength);
+			} else {
+				var thisRow = remainingRows.a;
+				var rest = remainingRows.b;
+				if (_Utils_eq(
+					$elm$core$List$length(thisRow),
+					rowLength)) {
+					var $temp$rowLength = rowLength,
+						$temp$rowNumber = rowNumber + 1,
+						$temp$remainingRows = rest;
+					rowLength = $temp$rowLength;
+					rowNumber = $temp$rowNumber;
+					remainingRows = $temp$remainingRows;
+					continue allRowsEqualLengthHelper;
+				} else {
+					return $elm$core$Result$Err(
+						$data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowLengthsDoNotMatch(rowNumber));
+				}
+			}
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$allRowsEqualLength = function (data) {
+	if (!data.b) {
+		return $elm$core$Result$Ok(0);
+	} else {
+		var row1 = data.a;
+		var remainingRows = data.b;
+		return A3(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Table$allRowsEqualLengthHelper,
+			$elm$core$List$length(row1),
+			2,
+			remainingRows);
+	}
+};
 var $elm$html$Html$text = $elm$virtual_dom$VirtualDom$text;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$generate = function (data) {
+	var _v0 = $data_viz_lab$elm_chart_builder$Chart$Internal$Table$allRowsEqualLength(data);
+	if (_v0.$ === 'Ok') {
+		var noOfCols = _v0.a;
+		return $elm$core$Result$Ok(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Table$TableConfiguration(
+				{
+					attributes: _List_Nil,
+					caption: $elm$core$Maybe$Nothing,
+					cells: A2(
+						$elm$core$List$map,
+						function (row) {
+							return A2(
+								$elm$core$List$map,
+								function (v) {
+									return $data_viz_lab$elm_chart_builder$Chart$Internal$Table$Cell(
+										{
+											attributes: _List_Nil,
+											value: $elm$html$Html$text(v)
+										});
+								},
+								row);
+						},
+						data),
+					columnHeadings: $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingsSimple(
+						A2(
+							$elm$core$List$map,
+							function (colNo) {
+								return $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingSingle(
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeading(
+										{
+											attributes: _List_Nil,
+											label: $elm$html$Html$text(
+												'Column ' + $elm$core$String$fromInt(colNo))
+										}));
+							},
+							A2($elm$core$List$range, 1, noOfCols))),
+					columnHeadingsShown: true,
+					rowHeadings: $data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowHeadingsSimple(
+						A2(
+							$elm$core$List$map,
+							function (rowNo) {
+								return $data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowHeadingSingle(
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Table$RowHeading(
+										{
+											attributes: _List_Nil,
+											label: $elm$html$Html$text(
+												'Row ' + $elm$core$String$fromInt(rowNo))
+										}));
+							},
+							A2(
+								$elm$core$List$range,
+								1,
+								$elm$core$List$length(data)))),
+					rowHeadingsShown: true,
+					summary: $elm$core$Maybe$Nothing
+				}));
+	} else {
+		var error = _v0.a;
+		return $elm$core$Result$Err(error);
+	}
+};
+var $elm$html$Html$figcaption = _VirtualDom_node('figcaption');
+var $elm$virtual_dom$VirtualDom$style = _VirtualDom_style;
+var $elm$html$Html$Attributes$style = $elm$virtual_dom$VirtualDom$style;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$invisibleFigcaption = function (content) {
+	return A2(
+		$elm$html$Html$figcaption,
+		_List_fromArray(
+			[
+				A2($elm$html$Html$Attributes$style, 'border', '0'),
+				A2($elm$html$Html$Attributes$style, 'clip', 'rect(0 0 0 0)'),
+				A2($elm$html$Html$Attributes$style, 'height', '1px'),
+				A2($elm$html$Html$Attributes$style, 'margin', '-1px'),
+				A2($elm$html$Html$Attributes$style, 'overflow', 'hidden'),
+				A2($elm$html$Html$Attributes$style, 'padding', '0'),
+				A2($elm$html$Html$Attributes$style, 'position', 'absolute'),
+				A2($elm$html$Html$Attributes$style, 'width', '1px')
+			]),
+		content);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingGroup = F2(
+	function (a, b) {
+		return {$: 'ColumnHeadingGroup', a: a, b: b};
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingMismatch = {$: 'ColumnHeadingMismatch'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingsComplex = function (a) {
+	return {$: 'ColumnHeadingsComplex', a: a};
+};
+var $elm$core$Result$andThen = F2(
+	function (callback, result) {
+		if (result.$ === 'Ok') {
+			var value = result.a;
+			return callback(value);
+		} else {
+			var msg = result.a;
+			return $elm$core$Result$Err(msg);
+		}
+	});
+var $elm$core$Result$map = F2(
+	function (func, ra) {
+		if (ra.$ === 'Ok') {
+			var a = ra.a;
+			return $elm$core$Result$Ok(
+				func(a));
+		} else {
+			var e = ra.a;
+			return $elm$core$Result$Err(e);
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$noOfComplexHeadings = function (complexHeadings) {
+	var addHeaders = F2(
+		function (header, acc) {
+			if (!header.b.b) {
+				return acc + 1;
+			} else {
+				var subHeadings = header.b;
+				return acc + $elm$core$List$length(subHeadings);
+			}
+		});
+	return A3($elm$core$List$foldl, addHeaders, 0, complexHeadings);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$setColumnHeadings = F2(
+	function (headings_, resultConfig) {
+		if (headings_.$ === 'Headings') {
+			var headings = headings_.a;
+			return A2(
+				$elm$core$Result$andThen,
+				function (_v2) {
+					var tableConfig = _v2.a;
+					return _Utils_eq(
+						$elm$core$List$length(headings),
+						$elm$core$List$length(
+							A2(
+								$elm$core$Maybe$withDefault,
+								_List_Nil,
+								$elm$core$List$head(tableConfig.cells)))) ? $elm$core$Result$Ok(
+						$data_viz_lab$elm_chart_builder$Chart$Internal$Table$TableConfiguration(tableConfig)) : $elm$core$Result$Err($data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingMismatch);
+				},
+				A2(
+					$elm$core$Result$map,
+					function (_v1) {
+						var tableConfig = _v1.a;
+						return $data_viz_lab$elm_chart_builder$Chart$Internal$Table$TableConfiguration(
+							_Utils_update(
+								tableConfig,
+								{
+									columnHeadings: $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingsSimple(
+										A2(
+											$elm$core$List$map,
+											function (label) {
+												return $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingSingle(
+													$data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeading(
+														{
+															attributes: _List_Nil,
+															label: $elm$html$Html$text(label)
+														}));
+											},
+											headings))
+								}));
+					},
+					resultConfig));
+		} else {
+			var complexHeadings = headings_.a;
+			return A2(
+				$elm$core$Result$andThen,
+				function (_v5) {
+					var tableConfig = _v5.a;
+					return _Utils_eq(
+						$data_viz_lab$elm_chart_builder$Chart$Internal$Table$noOfComplexHeadings(complexHeadings),
+						$elm$core$List$length(
+							A2(
+								$elm$core$Maybe$withDefault,
+								_List_Nil,
+								$elm$core$List$head(tableConfig.cells)))) ? $elm$core$Result$Ok(
+						$data_viz_lab$elm_chart_builder$Chart$Internal$Table$TableConfiguration(tableConfig)) : $elm$core$Result$Err($data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingMismatch);
+				},
+				A2(
+					$elm$core$Result$map,
+					function (_v3) {
+						var tableConfig = _v3.a;
+						return $data_viz_lab$elm_chart_builder$Chart$Internal$Table$TableConfiguration(
+							_Utils_update(
+								tableConfig,
+								{
+									columnHeadings: $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingsComplex(
+										A2(
+											$elm$core$List$map,
+											function (_v4) {
+												var mainHeading = _v4.a;
+												var subHeadings = _v4.b;
+												return A2(
+													$data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeadingGroup,
+													$data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeading(
+														{
+															attributes: _List_Nil,
+															label: $elm$html$Html$text(mainHeading)
+														}),
+													A2(
+														$elm$core$List$map,
+														function (subHeading) {
+															return $data_viz_lab$elm_chart_builder$Chart$Internal$Table$ColumnHeading(
+																{
+																	attributes: _List_Nil,
+																	label: $elm$html$Html$text(subHeading)
+																});
+														},
+														subHeadings));
+											},
+											complexHeadings))
+								}));
+					},
+					resultConfig));
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$NoData = {$: 'NoData'};
+var $elm$html$Html$col = _VirtualDom_node('col');
+var $elm$html$Html$colgroup = _VirtualDom_node('colgroup');
+var $elm$html$Html$Attributes$colspan = function (n) {
+	return A2(
+		_VirtualDom_attribute,
+		'colspan',
+		$elm$core$String$fromInt(n));
+};
+var $elm$json$Json$Encode$bool = _Json_wrap;
+var $elm$html$Html$Attributes$boolProperty = F2(
+	function (key, bool) {
+		return A2(
+			_VirtualDom_property,
+			key,
+			$elm$json$Json$Encode$bool(bool));
+	});
+var $elm$html$Html$Attributes$hidden = $elm$html$Html$Attributes$boolProperty('hidden');
+var $elm$html$Html$Attributes$rowspan = function (n) {
+	return A2(
+		_VirtualDom_attribute,
+		'rowspan',
+		$elm$core$String$fromInt(n));
+};
+var $elm$html$Html$Attributes$scope = $elm$html$Html$Attributes$stringProperty('scope');
+var $elm$html$Html$table = _VirtualDom_node('table');
+var $elm$html$Html$tbody = _VirtualDom_node('tbody');
+var $elm$html$Html$td = _VirtualDom_node('td');
+var $elm$html$Html$th = _VirtualDom_node('th');
+var $elm$html$Html$thead = _VirtualDom_node('thead');
+var $elm$html$Html$tr = _VirtualDom_node('tr');
+var $elm$core$Tuple$pair = F2(
+	function (a, b) {
+		return _Utils_Tuple2(a, b);
+	});
+var $elm_community$list_extra$List$Extra$zip = $elm$core$List$map2($elm$core$Tuple$pair);
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Table$view = function (config) {
+	if (config.$ === 'Ok') {
+		var tableConfig = config.a.a;
+		var columnHeadings = function () {
+			var _v6 = tableConfig.columnHeadings;
+			if (_v6.$ === 'ColumnHeadingsSimple') {
+				if (!_v6.a.b) {
+					return _List_Nil;
+				} else {
+					var cols = _v6.a;
+					var spacer = tableConfig.rowHeadingsShown ? _List_fromArray(
+						[
+							A2($elm$html$Html$td, _List_Nil, _List_Nil)
+						]) : _List_Nil;
+					return _List_fromArray(
+						[
+							A2(
+							$elm$html$Html$thead,
+							_List_Nil,
+							_List_fromArray(
+								[
+									A2(
+									$elm$html$Html$tr,
+									_List_fromArray(
+										[
+											$elm$html$Html$Attributes$hidden(!tableConfig.columnHeadingsShown)
+										]),
+									_Utils_ap(
+										spacer,
+										A2(
+											$elm$core$List$map,
+											function (_v7) {
+												var colInfo = _v7.a.a;
+												return A2(
+													$elm$html$Html$th,
+													_List_fromArray(
+														[
+															$elm$html$Html$Attributes$scope('col')
+														]),
+													_List_fromArray(
+														[colInfo.label]));
+											},
+											cols)))
+								]))
+						]);
+				}
+			} else {
+				if (!_v6.a.b) {
+					return _List_Nil;
+				} else {
+					var complexHeadings = _v6.a;
+					var subHeadings = $elm$core$List$concat(
+						A2(
+							$elm$core$List$map,
+							function (_v10) {
+								var subHeads = _v10.b;
+								return A2(
+									$elm$core$List$map,
+									function (_v11) {
+										var colInfo = _v11.a;
+										return A2(
+											$elm$html$Html$th,
+											_List_fromArray(
+												[
+													$elm$html$Html$Attributes$scope('col')
+												]),
+											_List_fromArray(
+												[colInfo.label]));
+									},
+									subHeads);
+							},
+							complexHeadings));
+					var spacer = tableConfig.rowHeadingsShown ? _List_fromArray(
+						[
+							A2(
+							$elm$html$Html$td,
+							_List_fromArray(
+								[
+									$elm$html$Html$Attributes$rowspan(2)
+								]),
+							_List_Nil)
+						]) : _List_Nil;
+					var mainHeadings = function () {
+						var cols = function (n) {
+							return (!n) ? _List_fromArray(
+								[
+									$elm$html$Html$Attributes$scope('col'),
+									$elm$html$Html$Attributes$rowspan(2)
+								]) : _List_fromArray(
+								[
+									$elm$html$Html$Attributes$scope('colgroup'),
+									$elm$html$Html$Attributes$colspan(n)
+								]);
+						};
+						return A2(
+							$elm$core$List$map,
+							function (_v9) {
+								var colInfo = _v9.a.a;
+								var subHeads = _v9.b;
+								return A2(
+									$elm$html$Html$th,
+									cols(
+										$elm$core$List$length(subHeads)),
+									_List_fromArray(
+										[colInfo.label]));
+							},
+							complexHeadings);
+					}();
+					var colStructure = function () {
+						var colgroup_ = function (n) {
+							return (!n) ? A2($elm$html$Html$col, _List_Nil, _List_Nil) : A2(
+								$elm$html$Html$colgroup,
+								_List_fromArray(
+									[
+										A2(
+										$elm$html$Html$Attributes$attribute,
+										'span',
+										$elm$core$String$fromInt(n))
+									]),
+								_List_Nil);
+						};
+						var colSpacer = tableConfig.rowHeadingsShown ? _List_fromArray(
+							[
+								A2($elm$html$Html$col, _List_Nil, _List_Nil)
+							]) : _List_Nil;
+						return _Utils_ap(
+							colSpacer,
+							A2(
+								$elm$core$List$map,
+								function (_v8) {
+									var subHeads = _v8.b;
+									return colgroup_(
+										$elm$core$List$length(subHeads));
+								},
+								complexHeadings));
+					}();
+					return _Utils_ap(
+						colStructure,
+						_List_fromArray(
+							[
+								A2(
+								$elm$html$Html$thead,
+								_List_Nil,
+								_List_fromArray(
+									[
+										A2(
+										$elm$html$Html$tr,
+										_List_fromArray(
+											[
+												$elm$html$Html$Attributes$hidden(!tableConfig.columnHeadingsShown)
+											]),
+										_Utils_ap(spacer, mainHeadings)),
+										A2(
+										$elm$html$Html$tr,
+										_List_fromArray(
+											[
+												$elm$html$Html$Attributes$hidden(!tableConfig.columnHeadingsShown)
+											]),
+										subHeadings)
+									]))
+							]));
+				}
+			}
+		}();
+		var body = function () {
+			var _v2 = tableConfig.cells;
+			if (!_v2.b) {
+				return _List_Nil;
+			} else {
+				var _v3 = tableConfig.rowHeadings;
+				var rowHeadings = _v3.a;
+				return _List_fromArray(
+					[
+						A2(
+						$elm$html$Html$tbody,
+						_List_Nil,
+						A2(
+							$elm$core$List$map,
+							function (_v4) {
+								var rowDataInfo = _v4.a;
+								var rowHeadingInfo = _v4.b.a.a;
+								return A2(
+									$elm$html$Html$tr,
+									_List_Nil,
+									_Utils_ap(
+										_List_fromArray(
+											[
+												A2(
+												$elm$html$Html$th,
+												_Utils_ap(
+													_List_fromArray(
+														[
+															$elm$html$Html$Attributes$scope('row'),
+															$elm$html$Html$Attributes$hidden(!tableConfig.rowHeadingsShown)
+														]),
+													rowHeadingInfo.attributes),
+												_List_fromArray(
+													[rowHeadingInfo.label]))
+											]),
+										A2(
+											$elm$core$List$map,
+											function (_v5) {
+												var cell = _v5.a;
+												return A2(
+													$elm$html$Html$td,
+													cell.attributes,
+													_List_fromArray(
+														[cell.value]));
+											},
+											rowDataInfo)));
+							},
+							A2($elm_community$list_extra$List$Extra$zip, tableConfig.cells, rowHeadings)))
+					]);
+			}
+		}();
+		if (!body.b) {
+			return $elm$core$Result$Err($data_viz_lab$elm_chart_builder$Chart$Internal$Table$NoData);
+		} else {
+			return $elm$core$Result$Ok(
+				A2(
+					$elm$html$Html$table,
+					_List_Nil,
+					_Utils_ap(columnHeadings, body)));
+		}
+	} else {
+		var error = config.a;
+		return $elm$core$Result$Err(error);
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$tableElement = F2(
+	function (config, data) {
+		var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+		var tableData = A2($data_viz_lab$elm_chart_builder$Chart$Internal$TableHelpers$dataBandToTableData, c, data);
+		var tableHeadings = A2($data_viz_lab$elm_chart_builder$Chart$Internal$TableHelpers$dataBandToTableHeadings, data, c.accessibilityContent);
+		var table = $data_viz_lab$elm_chart_builder$Chart$Internal$Table$view(
+			A2(
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Table$setColumnHeadings,
+				tableHeadings,
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Table$generate(tableData)));
+		return $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$invisibleFigcaption(
+			_List_fromArray(
+				[
+					function () {
+					if (table.$ === 'Ok') {
+						var table_ = table.a;
+						return A2(
+							$elm$html$Html$div,
+							_List_Nil,
+							_List_fromArray(
+								[table_]));
+					} else {
+						var error = table.a;
+						return $elm$html$Html$text(
+							$data_viz_lab$elm_chart_builder$Chart$Internal$Table$errorToString(error));
+					}
+				}()
+				]));
+	});
+var $elm_community$typed_svg$TypedSvg$Attributes$viewBox = F4(
+	function (minX, minY, vWidth, vHeight) {
+		return A2(
+			$elm_community$typed_svg$TypedSvg$Core$attribute,
+			'viewBox',
+			A2(
+				$elm$core$String$join,
+				' ',
+				A2(
+					$elm$core$List$map,
+					$elm$core$String$fromFloat,
+					_List_fromArray(
+						[minX, minY, vWidth, vHeight]))));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$renderBandGrouped = function (_v0) {
+	var data = _v0.a;
+	var config = _v0.b;
+	var paddingInner = A2(
+		$gampleman$elm_visualization$Scale$convert,
+		$gampleman$elm_visualization$Scale$clamp(
+			A2(
+				$gampleman$elm_visualization$Scale$linear,
+				_Utils_Tuple2(0.2, 0.999),
+				_Utils_Tuple2(0, 500))),
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDataBandDepth(data));
+	var domain = A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDomainBandFromData, data, config);
+	var dataLength = $elm$core$List$length(
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data));
+	var paddingInnerGroup = (dataLength === 1) ? 0 : 0.1;
+	var colorScale = A2(
+		$gampleman$elm_visualization$Scale$linear,
+		_Utils_Tuple2(0, 1),
+		A2(
+			$elm$core$Maybe$withDefault,
+			_Utils_Tuple2(0, 0),
+			domain.continuous));
+	var classNames = $elm$html$Html$Attributes$classList(
+		_List_fromArray(
+			[
+				_Utils_Tuple2($data_viz_lab$elm_chart_builder$Chart$Internal$Constants$rootClassName, true),
+				_Utils_Tuple2($data_viz_lab$elm_chart_builder$Chart$Internal$Constants$barClassName, true)
+			]));
+	var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+	var h = c.height;
+	var m = c.margin;
+	var p = c.padding;
+	var outerH = A3($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$outerHeight, h, m, p);
+	var w = c.width;
+	var outerW = A3($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$outerWidth, w, m, p);
+	var svgElAttrs = _Utils_ap(
+		_List_fromArray(
+			[
+				A4($elm_community$typed_svg$TypedSvg$Attributes$viewBox, 0, 0, outerW, outerH),
+				$elm_community$typed_svg$TypedSvg$Attributes$InPx$width(outerW),
+				$elm_community$typed_svg$TypedSvg$Attributes$InPx$height(outerH),
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$role('img'),
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaHidden
+			]),
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaLabelledbyContent(c));
+	var bandGroupRange = A3($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getBandGroupRange, config, w, h);
+	var bandGroupScale = A3(
+		$gampleman$elm_visualization$Scale$band,
+		_Utils_update(
+			$gampleman$elm_visualization$Scale$defaultBandConfig,
+			{paddingInner: paddingInnerGroup, paddingOuter: paddingInnerGroup}),
+		bandGroupRange,
+		A2($elm$core$Maybe$withDefault, _List_Nil, domain.bandGroup));
+	var bandSingleRange = A2(
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$getBandSingleRange,
+		config,
+		$gampleman$elm_visualization$Scale$bandwidth(bandGroupScale));
+	var bandSingleScale = A3(
+		$gampleman$elm_visualization$Scale$band,
+		_Utils_update(
+			$gampleman$elm_visualization$Scale$defaultBandConfig,
+			{paddingInner: paddingInner, paddingOuter: paddingInner / 2}),
+		bandSingleRange,
+		A2($elm$core$Maybe$withDefault, _List_Nil, domain.bandSingle));
+	var continuousRange = A5($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getContinuousRange, config, $data_viz_lab$elm_chart_builder$Chart$Internal$Type$RenderChart, w, h, bandSingleScale);
+	var continuousScale = A2(
+		$gampleman$elm_visualization$Scale$linear,
+		continuousRange,
+		A2(
+			$elm$core$Maybe$withDefault,
+			_Utils_Tuple2(0, 0),
+			domain.continuous));
+	var iconOffset = $elm$core$List$isEmpty(c.symbols) ? 0 : (A3($data_viz_lab$elm_chart_builder$Chart$Internal$Type$symbolSpace, $data_viz_lab$elm_chart_builder$Chart$Internal$Type$Vertical, bandSingleScale, c.symbols) + $data_viz_lab$elm_chart_builder$Chart$Internal$Symbol$symbolGap);
+	var symbolElements = function () {
+		var _v2 = c.layout;
+		if (_v2.$ === 'GroupedBar') {
+			return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showIcons(config) ? A3($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$symbolsToSymbolElements, c.orientation, bandSingleScale, c.symbols) : _List_Nil;
+		} else {
+			return _List_Nil;
+		}
+	}();
+	var axisBandScale = ($elm$core$List$length(
+		A2($elm$core$Maybe$withDefault, _List_Nil, domain.bandGroup)) > 1) ? bandGroupScale : bandSingleScale;
+	var svgEl = A2(
+		$elm_community$typed_svg$TypedSvg$svg,
+		svgElAttrs,
+		_Utils_ap(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$descAndTitle(c),
+			_Utils_ap(
+				A3($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$bandGroupedYAxis, c, iconOffset, continuousScale),
+				_Utils_ap(
+					A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$bandXAxis, c, axisBandScale),
+					_Utils_ap(
+						_List_fromArray(
+							[
+								A2(
+								$elm_community$typed_svg$TypedSvg$g,
+								_List_fromArray(
+									[
+										$elm_community$typed_svg$TypedSvg$Attributes$transform(
+										_List_fromArray(
+											[
+												A2($elm_community$typed_svg$TypedSvg$Types$Translate, m.left + p.left, m.top + p.top)
+											])),
+										$elm_community$typed_svg$TypedSvg$Attributes$class(
+										_List_fromArray(
+											[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+									]),
+								A2(
+									$elm$core$List$map,
+									A6($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$columns, config, iconOffset, bandGroupScale, bandSingleScale, continuousScale, colorScale),
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data)))
+							]),
+						symbolElements)))));
+	var _v1 = c.accessibilityContent;
+	if (_v1.$ === 'AccessibilityNone') {
+		return A2(
+			$elm$html$Html$div,
+			_List_fromArray(
+				[classNames]),
+			_List_fromArray(
+				[svgEl]));
+	} else {
+		return A2(
+			$elm$html$Html$div,
+			_List_fromArray(
+				[classNames]),
+			_List_fromArray(
+				[
+					A2(
+					$elm$html$Html$figure,
+					_List_Nil,
+					_List_fromArray(
+						[
+							svgEl,
+							A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$tableElement, config, data)
+						]))
+				]));
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$RenderAxis = {$: 'RenderAxis'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$adjustContinuousRange = F3(
+	function (config, stackedDepth, _v0) {
+		var a = _v0.a;
+		var b = _v0.b;
+		var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+		var layout = c.layout;
+		var orientation = c.orientation;
+		if (orientation.$ === 'Horizontal') {
+			if (layout.$ === 'GroupedBar') {
+				return _Utils_Tuple2(a, b);
+			} else {
+				return _Utils_Tuple2(a + stackedDepth, b);
+			}
+		} else {
+			return _Utils_Tuple2(a - stackedDepth, b);
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$dataBandToDataStacked = F2(
+	function (config, data) {
+		var seed = A2(
+			$elm$core$List$map,
+			function (d) {
+				return _Utils_Tuple2(d, _List_Nil);
+			},
+			A2(
+				$elm$core$Maybe$withDefault,
+				_List_Nil,
+				A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDomainBandFromData, data, config).bandSingle));
+		return A3(
+			$elm$core$List$foldl,
+			F2(
+				function (d, acc) {
+					return A2(
+						$elm$core$List$map,
+						function (a) {
+							return _Utils_eq(d.a, a.a) ? _Utils_Tuple2(
+								a.a,
+								A2($elm$core$List$cons, d.b, a.b)) : a;
+						},
+						acc);
+				}),
+			seed,
+			$elm$core$List$concat(
+				A2(
+					$elm$core$List$map,
+					function ($) {
+						return $.points;
+					},
+					$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data))));
+	});
+var $elm$core$Set$foldr = F3(
+	function (func, initialState, _v0) {
+		var dict = _v0.a;
+		return A3(
+			$elm$core$Dict$foldr,
+			F3(
+				function (key, _v1, state) {
+					return A2(func, key, state);
+				}),
+			initialState,
+			dict);
+	});
+var $elm$core$Set$Set_elm_builtin = function (a) {
+	return {$: 'Set_elm_builtin', a: a};
+};
+var $elm$core$Set$empty = $elm$core$Set$Set_elm_builtin($elm$core$Dict$empty);
+var $elm$core$Set$insert = F2(
+	function (key, _v0) {
+		var dict = _v0.a;
+		return $elm$core$Set$Set_elm_builtin(
+			A3($elm$core$Dict$insert, key, _Utils_Tuple0, dict));
+	});
+var $elm$core$Set$fromList = function (list) {
+	return A3($elm$core$List$foldl, $elm$core$Set$insert, $elm$core$Set$empty, list);
+};
+var $elm$core$List$sortBy = _List_sortBy;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toDataBand = function (dataBand) {
+	return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$DataBand(dataBand);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fillGapsForStack = function (data) {
+	var d = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data);
+	var allStrings = $elm$core$Set$fromList(
+		$elm$core$List$concat(
+			A2(
+				$elm$core$List$map,
+				A2(
+					$elm$core$Basics$composeR,
+					function ($) {
+						return $.points;
+					},
+					$elm$core$List$map($elm$core$Tuple$first)),
+				d)));
+	var fillGaps = function (dataGroupBand) {
+		var points = A2($elm$core$List$map, $elm$core$Tuple$first, dataGroupBand.points);
+		var newPoints = A2(
+			$elm$core$List$sortBy,
+			$elm$core$Tuple$first,
+			A2(
+				$elm$core$List$append,
+				dataGroupBand.points,
+				A3(
+					$elm$core$Set$foldr,
+					F2(
+						function (s, acc) {
+							return A2($elm$core$List$member, s, points) ? acc : A2(
+								$elm$core$List$cons,
+								_Utils_Tuple2(s, 0),
+								acc);
+						}),
+					_List_Nil,
+					allStrings)));
+		return _Utils_update(
+			dataGroupBand,
+			{points: newPoints});
+	};
+	return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toDataBand(
+		A2($elm$core$List$map, fillGaps, d));
+};
+var $elmcraft$core_extra$List$Extra$rowsLength = function (listOfLists) {
+	if (!listOfLists.b) {
+		return 0;
+	} else {
+		var x = listOfLists.a;
+		return $elm$core$List$length(x);
+	}
+};
+var $elmcraft$core_extra$List$Extra$transpose = function (listOfLists) {
+	return A3(
+		$elm$core$List$foldr,
+		$elm$core$List$map2($elm$core$List$cons),
+		A2(
+			$elm$core$List$repeat,
+			$elmcraft$core_extra$List$Extra$rowsLength(listOfLists),
+			_List_Nil),
+		listOfLists);
+};
+var $gampleman$elm_visualization$Shape$Stack$offsetDiverging = function (series) {
+	var folder = F2(
+		function (_v1, _v2) {
+			var x = _v1.a;
+			var y = _v1.b;
+			var yp = _v2.a;
+			var yn = _v2.b;
+			var accum = _v2.c;
+			var dy = y - x;
+			return (dy >= 0) ? _Utils_Tuple3(
+				yp + dy,
+				yn,
+				A2(
+					$elm$core$List$cons,
+					_Utils_Tuple2(yp, yp + dy),
+					accum)) : ((dy < 0) ? _Utils_Tuple3(
+				yp,
+				yn + dy,
+				A2(
+					$elm$core$List$cons,
+					_Utils_Tuple2(yn + dy, yn),
+					accum)) : _Utils_Tuple3(
+				yp,
+				yn,
+				A2(
+					$elm$core$List$cons,
+					_Utils_Tuple2(yp, y),
+					accum)));
+		});
+	var modifyColumn = function (column) {
+		return $elm$core$List$reverse(
+			function (_v0) {
+				var newColumn = _v0.c;
+				return newColumn;
+			}(
+				A3(
+					$elm$core$List$foldl,
+					folder,
+					_Utils_Tuple3(0, 0, _List_Nil),
+					column)));
+	};
+	return $elmcraft$core_extra$List$Extra$transpose(
+		A2(
+			$elm$core$List$map,
+			modifyColumn,
+			$elmcraft$core_extra$List$Extra$transpose(series)));
+};
+var $gampleman$elm_visualization$Shape$stackOffsetDiverging = $gampleman$elm_visualization$Shape$Stack$offsetDiverging;
+var $gampleman$elm_visualization$Shape$Stack$offsetNone = function (series) {
+	if (!series.b) {
+		return _List_Nil;
+	} else {
+		var x = series.a;
+		var xs = series.b;
+		var weirdAdd = F2(
+			function (_v3, _v4) {
+				var s11 = _v3.b;
+				var s00 = _v4.a;
+				var s01 = _v4.b;
+				return $elm$core$Basics$isNaN(s01) ? _Utils_Tuple2(s00, s11 + s00) : _Utils_Tuple2(s01, s11 + s01);
+			});
+		var helper = F2(
+			function (s1, _v2) {
+				var s0 = _v2.a;
+				var accum = _v2.b;
+				return _Utils_Tuple2(
+					A3($elm$core$List$map2, weirdAdd, s1, s0),
+					A2($elm$core$List$cons, s0, accum));
+			});
+		return $elm$core$List$reverse(
+			function (_v1) {
+				var a = _v1.a;
+				var b = _v1.b;
+				return A2($elm$core$List$cons, a, b);
+			}(
+				A3(
+					$elm$core$List$foldl,
+					helper,
+					_Utils_Tuple2(x, _List_Nil),
+					xs)));
+	}
+};
+var $gampleman$elm_visualization$Shape$stackOffsetNone = $gampleman$elm_visualization$Shape$Stack$offsetNone;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getOffset = function (config) {
+	var _v0 = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config).layout;
+	if (_v0.$ === 'StackedBar') {
+		var direction = _v0.a;
+		if (direction.$ === 'Diverging') {
+			return $gampleman$elm_visualization$Shape$stackOffsetDiverging;
+		} else {
+			return $gampleman$elm_visualization$Shape$stackOffsetNone;
+		}
+	} else {
+		return $gampleman$elm_visualization$Shape$stackOffsetNone;
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getStackedValuesAndGroupes = F2(
+	function (values, data) {
+		var m = $elm$core$List$map2(
+			F2(
+				function (d, v) {
+					return A3(
+						$elm$core$List$map2,
+						F2(
+							function (stackedValue, rawValue) {
+								return {rawValue: rawValue.b, stackedValue: stackedValue};
+							}),
+						v,
+						d.points);
+				}));
+		return _Utils_Tuple2(
+			A2(
+				m,
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data),
+				$elm$core$List$reverse(
+					$elm_community$list_extra$List$Extra$transpose(values))),
+			A2(
+				$elm$core$List$indexedMap,
+				F2(
+					function (idx, s) {
+						return A2(
+							$elm$core$Maybe$withDefault,
+							$elm$core$String$fromInt(idx),
+							s.groupLabel);
+					}),
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromDataBand(data)));
+	});
+var $elm$core$Maybe$map = F2(
+	function (f, maybe) {
+		if (maybe.$ === 'Just') {
+			var value = maybe.a;
+			return $elm$core$Maybe$Just(
+				f(value));
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
+	});
+var $gampleman$elm_visualization$Shape$Stack$calculateExtremes = function (coords) {
+	var folder = F2(
+		function (_v2, _v3) {
+			var y1 = _v2.a;
+			var y2 = _v2.b;
+			var accmin = _v3.a;
+			var accmax = _v3.b;
+			return _Utils_Tuple2(
+				A2(
+					$elm$core$Basics$min,
+					accmin,
+					A2($elm$core$Basics$min, y1, y2)),
+				A2(
+					$elm$core$Basics$max,
+					accmax,
+					A2($elm$core$Basics$max, y1, y2)));
+		});
+	return A3(
+		$elm$core$List$foldl,
+		F2(
+			function (_v0, _v1) {
+				var mi = _v0.a;
+				var ma = _v0.b;
+				var accmin = _v1.a;
+				var accmax = _v1.b;
+				return _Utils_Tuple2(
+					A2($elm$core$Basics$min, mi, accmin),
+					A2($elm$core$Basics$max, ma, accmax));
+			}),
+		_Utils_Tuple2(0, 0),
+		A2(
+			$elm$core$List$map,
+			A2(
+				$elm$core$List$foldl,
+				folder,
+				_Utils_Tuple2(0, 0)),
+			coords));
+};
+var $elm$core$List$unzip = function (pairs) {
+	var step = F2(
+		function (_v0, _v1) {
+			var x = _v0.a;
+			var y = _v0.b;
+			var xs = _v1.a;
+			var ys = _v1.b;
+			return _Utils_Tuple2(
+				A2($elm$core$List$cons, x, xs),
+				A2($elm$core$List$cons, y, ys));
+		});
+	return A3(
+		$elm$core$List$foldr,
+		step,
+		_Utils_Tuple2(_List_Nil, _List_Nil),
+		pairs);
+};
+var $gampleman$elm_visualization$Shape$Stack$computeStack = function (_v0) {
+	var offset = _v0.offset;
+	var order = _v0.order;
+	var data = _v0.data;
+	var _v1 = $elm$core$List$unzip(
+		order(data));
+	var labels = _v1.a;
+	var values = _v1.b;
+	var stacked = offset(
+		A2(
+			$elm$core$List$map,
+			$elm$core$List$map(
+				function (e) {
+					return _Utils_Tuple2(0, e);
+				}),
+			values));
+	return {
+		extent: $gampleman$elm_visualization$Shape$Stack$calculateExtremes(stacked),
+		labels: labels,
+		values: stacked
+	};
+};
+var $gampleman$elm_visualization$Shape$stack = $gampleman$elm_visualization$Shape$Stack$computeStack;
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$colorCategoricalStyle = F2(
+	function (c, idx) {
+		var _v0 = c.colorResource;
+		if (_v0.$ === 'ColorPalette') {
+			var colors = _v0.a;
+			return 'fill: ' + A2($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$colorPaletteToColor, colors, idx);
+		} else {
+			return '';
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$getStackedLabel = F2(
+	function (idx, l) {
+		return A2(
+			$elm$core$Maybe$withDefault,
+			'',
+			A2($elm_community$list_extra$List$Extra$getAt, idx, l));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$stackedColumnTitleText = F4(
+	function (c, idx, labels, value) {
+		var ordinalValue = A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$getStackedLabel, idx, labels);
+		var _v0 = c.showColumnTitle;
+		switch (_v0.$) {
+			case 'StackedColumnTitle':
+				var formatter = _v0.a;
+				return _List_fromArray(
+					[
+						A2(
+						$elm_community$typed_svg$TypedSvg$title,
+						_List_Nil,
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(
+								ordinalValue + (': ' + formatter(value)))
+							]))
+					]);
+			case 'YColumnTitle':
+				var formatter = _v0.a;
+				return _List_fromArray(
+					[
+						A2(
+						$elm_community$typed_svg$TypedSvg$title,
+						_List_Nil,
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(
+								formatter(value))
+							]))
+					]);
+			case 'XOrdinalColumnTitle':
+				return _List_fromArray(
+					[
+						A2(
+						$elm_community$typed_svg$TypedSvg$title,
+						_List_Nil,
+						_List_fromArray(
+							[
+								$elm_community$typed_svg$TypedSvg$Core$text(ordinalValue)
+							]))
+					]);
+			default:
+				return _List_Nil;
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$stackedValuesInverse = F2(
+	function (width, values) {
+		return A2(
+			$elm$core$List$map,
+			function (v) {
+				var _v0 = v.stackedValue;
+				var left = _v0.a;
+				var right = _v0.b;
+				return _Utils_update(
+					v,
+					{
+						stackedValue: _Utils_Tuple2(
+							$elm$core$Basics$abs(left - width),
+							$elm$core$Basics$abs(right - width))
+					});
+			},
+			values);
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalRectsStacked = F3(
+	function (c, bandGroupScale, _v0) {
+		var group = _v0.a;
+		var values = _v0.b;
+		var labels = _v0.c;
+		var block = F2(
+			function (idx, _v2) {
+				var rawValue = _v2.rawValue;
+				var stackedValue = _v2.stackedValue;
+				var coreStyle = $elm_community$typed_svg$TypedSvg$Attributes$style(
+					A2(
+						$data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles,
+						c.coreStyle,
+						A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$colorCategoricalStyle, c, idx)));
+				var _v1 = stackedValue;
+				var lower = _v1.a;
+				var upper = _v1.b;
+				var rect_ = A2(
+					$elm_community$typed_svg$TypedSvg$rect,
+					_List_fromArray(
+						[
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$y(
+							A2($gampleman$elm_visualization$Scale$convert, bandGroupScale, group)),
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$x(lower + idx),
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$height(
+							$gampleman$elm_visualization$Scale$bandwidth(bandGroupScale)),
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$width(
+							$elm$core$Basics$abs(upper - lower)),
+							$elm_community$typed_svg$TypedSvg$Attributes$shapeRendering($elm_community$typed_svg$TypedSvg$Types$RenderCrispEdges),
+							coreStyle
+						]),
+					A4($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$stackedColumnTitleText, c, idx, labels, rawValue));
+				return A2(
+					$elm_community$typed_svg$TypedSvg$g,
+					_List_fromArray(
+						[
+							$elm_community$typed_svg$TypedSvg$Attributes$class(
+							_List_fromArray(
+								[
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName,
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName + ('-' + $elm$core$String$fromInt(idx))
+								]))
+						]),
+					_List_fromArray(
+						[rect_]));
+			});
+		return A2(
+			$elm$core$List$indexedMap,
+			function (idx) {
+				return block(idx);
+			},
+			A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$stackedValuesInverse, c.width, values));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalRectsStacked = F3(
+	function (c, bandGroupScale, _v0) {
+		var group = _v0.a;
+		var values = _v0.b;
+		var labels = _v0.c;
+		var bandValue = A2($gampleman$elm_visualization$Scale$convert, bandGroupScale, group);
+		var block = F2(
+			function (idx, _v2) {
+				var rawValue = _v2.rawValue;
+				var stackedValue = _v2.stackedValue;
+				var coreStyleFromX = c.coreStyleFromPointBandX(
+					A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$getStackedLabel, idx, labels));
+				var coreStyle = $elm_community$typed_svg$TypedSvg$Attributes$style(
+					A2(
+						$data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles,
+						coreStyleFromX,
+						A2(
+							$data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$mergeStyles,
+							c.coreStyle,
+							A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$colorCategoricalStyle, c, idx))));
+				var _v1 = stackedValue;
+				var upper = _v1.a;
+				var lower = _v1.b;
+				var rect_ = A2(
+					$elm_community$typed_svg$TypedSvg$rect,
+					_List_fromArray(
+						[
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$x(bandValue),
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$y(lower - idx),
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$width(
+							$gampleman$elm_visualization$Scale$bandwidth(bandGroupScale)),
+							$elm_community$typed_svg$TypedSvg$Attributes$InPx$height(
+							$elm$core$Basics$abs(upper - lower)),
+							$elm_community$typed_svg$TypedSvg$Attributes$shapeRendering($elm_community$typed_svg$TypedSvg$Types$RenderCrispEdges),
+							coreStyle
+						]),
+					A4($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$stackedColumnTitleText, c, idx, labels, rawValue));
+				return A2(
+					$elm_community$typed_svg$TypedSvg$g,
+					_List_fromArray(
+						[
+							$elm_community$typed_svg$TypedSvg$Attributes$class(
+							_List_fromArray(
+								[
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName,
+									$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName + ('-' + $elm$core$String$fromInt(idx))
+								]))
+						]),
+					_List_fromArray(
+						[rect_]));
+			});
+		return A2(
+			$elm$core$List$indexedMap,
+			function (idx) {
+				return block(idx);
+			},
+			values);
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$stackedColumns = F3(
+	function (config, bandGroupScale, payload) {
+		var rects = function () {
+			var _v0 = config.orientation;
+			if (_v0.$ === 'Vertical') {
+				return A3($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$verticalRectsStacked, config, bandGroupScale, payload);
+			} else {
+				return A3($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$horizontalRectsStacked, config, bandGroupScale, payload);
+			}
+		}();
+		return A2(
+			$elm_community$typed_svg$TypedSvg$g,
+			_List_fromArray(
+				[
+					$elm_community$typed_svg$TypedSvg$Attributes$class(
+					_List_fromArray(
+						[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$columnClassName]))
+				]),
+			rects);
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$stackedContainerTranslate = F3(
+	function (config, a, b) {
+		var orientation = config.orientation;
+		if (orientation.$ === 'Horizontal') {
+			return A2($elm_community$typed_svg$TypedSvg$Types$Translate, a, b);
+		} else {
+			return A2($elm_community$typed_svg$TypedSvg$Types$Translate, a, b);
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$renderBandStacked = function (_v0) {
+	var data = _v0.a;
+	var config = _v0.b;
+	var noGapsData = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fillGapsForStack(data);
+	var stackDepth = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDataBandDepth(noGapsData);
+	var domain = A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getDomainBandFromData, data, config);
+	var dataStacked = A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$dataBandToDataStacked, config, noGapsData);
+	var stackedConfig = {
+		data: dataStacked,
+		offset: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$getOffset(config),
+		order: $elm$core$Basics$identity
+	};
+	var continuousDomain = domain.continuous;
+	var classNames = $elm$html$Html$Attributes$classList(
+		_List_fromArray(
+			[
+				_Utils_Tuple2($data_viz_lab$elm_chart_builder$Chart$Internal$Constants$rootClassName, true),
+				_Utils_Tuple2($data_viz_lab$elm_chart_builder$Chart$Internal$Constants$barClassName, true)
+			]));
+	var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+	var h = c.height;
+	var m = c.margin;
+	var p = c.padding;
+	var outerH = A3($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$outerHeight, h, m, p);
+	var w = c.width;
+	var outerW = A3($data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$outerWidth, w, m, p);
+	var svgElAttrs = _Utils_ap(
+		_List_fromArray(
+			[
+				A4($elm_community$typed_svg$TypedSvg$Attributes$viewBox, 0, 0, outerW, outerH),
+				$elm_community$typed_svg$TypedSvg$Attributes$InPx$width(outerW),
+				$elm_community$typed_svg$TypedSvg$Attributes$InPx$height(outerH),
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$role('img'),
+				$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaHidden
+			]),
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$ariaLabelledbyContent(c));
+	var bandGroupRange = A3($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getBandGroupRange, config, w, h);
+	var bandGroupScale = A3(
+		$gampleman$elm_visualization$Scale$band,
+		_Utils_update(
+			$gampleman$elm_visualization$Scale$defaultBandConfig,
+			{paddingInner: 0.1, paddingOuter: 0.05}),
+		bandGroupRange,
+		A2($elm$core$Maybe$withDefault, _List_Nil, domain.bandGroup));
+	var bandSingleRange = A2(
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$getBandSingleRange,
+		config,
+		$gampleman$elm_visualization$Scale$bandwidth(bandGroupScale));
+	var bandSingleScale = A3(
+		$gampleman$elm_visualization$Scale$band,
+		$gampleman$elm_visualization$Scale$defaultBandConfig,
+		bandSingleRange,
+		A2($elm$core$Maybe$withDefault, _List_Nil, domain.bandSingle));
+	var continuousRange = A3(
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$adjustContinuousRange,
+		config,
+		stackDepth,
+		A5($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getContinuousRange, config, $data_viz_lab$elm_chart_builder$Chart$Internal$Type$RenderChart, w, h, bandSingleScale));
+	var continuousRangeAxis = A3(
+		$data_viz_lab$elm_chart_builder$Chart$Internal$Type$adjustContinuousRange,
+		config,
+		stackDepth,
+		A5($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getContinuousRange, config, $data_viz_lab$elm_chart_builder$Chart$Internal$Type$RenderAxis, w, h, bandSingleScale));
+	var axisBandScale = bandGroupScale;
+	var _v1 = $gampleman$elm_visualization$Shape$stack(stackedConfig);
+	var values = _v1.values;
+	var labels = _v1.labels;
+	var extent = _v1.extent;
+	var continuousExtent = function () {
+		if (continuousDomain.$ === 'Just') {
+			var ld = continuousDomain.a;
+			var _v6 = c.layout;
+			if (_v6.$ === 'StackedBar') {
+				var direction = _v6.a;
+				if (direction.$ === 'Diverging') {
+					return A2(
+						$elm$core$Maybe$withDefault,
+						_Utils_Tuple2(0, 0),
+						A2(
+							$elm$core$Maybe$map,
+							function (max) {
+								return _Utils_Tuple2(max * (-1), max);
+							},
+							$elm$core$List$maximum(
+								_List_fromArray(
+									[
+										$elm$core$Basics$abs(ld.a),
+										$elm$core$Basics$abs(ld.b)
+									]))));
+				} else {
+					return extent;
+				}
+			} else {
+				return extent;
+			}
+		} else {
+			return extent;
+		}
+	}();
+	var continuousScale = A2($gampleman$elm_visualization$Scale$linear, continuousRange, continuousExtent);
+	var continuousScaleAxis = A2($gampleman$elm_visualization$Scale$linear, continuousRangeAxis, continuousExtent);
+	var _v2 = A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$getStackedValuesAndGroupes, values, noGapsData);
+	var columnValues = _v2.a;
+	var columnGroupes = _v2.b;
+	var scaledValues = A2(
+		$elm$core$List$map,
+		$elm$core$List$map(
+			function (vals) {
+				var _v4 = vals.stackedValue;
+				var a1 = _v4.a;
+				var a2 = _v4.b;
+				return _Utils_update(
+					vals,
+					{
+						stackedValue: _Utils_Tuple2(
+							A2($gampleman$elm_visualization$Scale$convert, continuousScale, a1),
+							A2($gampleman$elm_visualization$Scale$convert, continuousScale, a2))
+					});
+			}),
+		columnValues);
+	var svgEl = A2(
+		$elm_community$typed_svg$TypedSvg$svg,
+		svgElAttrs,
+		_Utils_ap(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$descAndTitle(c),
+			_Utils_ap(
+				A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$bandXAxis, c, axisBandScale),
+				_Utils_ap(
+					A3($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$bandGroupedYAxis, c, 0, continuousScaleAxis),
+					_List_fromArray(
+						[
+							A2(
+							$elm_community$typed_svg$TypedSvg$g,
+							_List_fromArray(
+								[
+									$elm_community$typed_svg$TypedSvg$Attributes$transform(
+									_List_fromArray(
+										[
+											A3($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$stackedContainerTranslate, c, m.left, m.top)
+										])),
+									$elm_community$typed_svg$TypedSvg$Attributes$class(
+									_List_fromArray(
+										[$data_viz_lab$elm_chart_builder$Chart$Internal$Constants$componentClassName]))
+								]),
+							A2(
+								$elm$core$List$map,
+								A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$stackedColumns, c, bandGroupScale),
+								A3(
+									$elm$core$List$map2,
+									F2(
+										function (a, b) {
+											return _Utils_Tuple3(a, b, labels);
+										}),
+									columnGroupes,
+									scaledValues)))
+						])))));
+	var _v3 = c.accessibilityContent;
+	if (_v3.$ === 'AccessibilityNone') {
+		return A2(
+			$elm$html$Html$div,
+			_List_fromArray(
+				[classNames]),
+			_List_fromArray(
+				[svgEl]));
+	} else {
+		return A2(
+			$elm$html$Html$div,
+			_List_fromArray(
+				[classNames]),
+			_List_fromArray(
+				[
+					A2(
+					$elm$html$Html$figure,
+					_List_Nil,
+					_List_fromArray(
+						[
+							svgEl,
+							A2($data_viz_lab$elm_chart_builder$Chart$Internal$Bar$tableElement, config, noGapsData)
+						]))
+				]));
+	}
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$ExternalData = function (a) {
+	return {$: 'ExternalData', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toExternalData = function (data) {
+	return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$ExternalData(data);
+};
+var $data_viz_lab$elm_chart_builder$Chart$Bar$render = F2(
+	function (_v0, config) {
+		var externalData = _v0.a;
+		var accessor = _v0.b;
+		var data = A2(
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$externalToDataBand,
+			$data_viz_lab$elm_chart_builder$Chart$Internal$Type$toExternalData(externalData),
+			accessor);
+		var c = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$fromConfig(config);
+		var _v1 = c.layout;
+		switch (_v1.$) {
+			case 'GroupedBar':
+				return $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$renderBandGrouped(
+					_Utils_Tuple2(data, config));
+			case 'StackedBar':
+				return $data_viz_lab$elm_chart_builder$Chart$Internal$Bar$renderBandStacked(
+					_Utils_Tuple2(data, config));
+			default:
+				return $elm$html$Html$text('');
+		}
+	});
+var $author$project$Main$plot = function (ls) {
+	return A2(
+		$data_viz_lab$elm_chart_builder$Chart$Bar$render,
+		_Utils_Tuple2(
+			ls,
+			{
+				xGroup: $elm$core$Basics$always($elm$core$Maybe$Nothing),
+				xValue: function (_v0) {
+					var p = _v0.a;
+					return $elm$core$String$fromInt(p);
+				},
+				yValue: function (_v1) {
+					var f = _v1.b;
+					return f;
+				}
+			}),
+		$data_viz_lab$elm_chart_builder$Chart$Bar$init(
+			{
+				height: 200,
+				margin: {bottom: 30, left: 30, right: 10, top: 10},
+				width: 500
+			}));
+};
+var $elm$html$Html$select = _VirtualDom_node('select');
 var $author$project$Main$toDutchWeekday = function (t) {
 	return function () {
 		switch (t.$) {
@@ -7210,8 +11993,7 @@ var $author$project$Main$view = function (_v0) {
 								var d2 = _v7.b;
 								return _List_fromArray(
 									[
-										$elm$html$Html$text(
-										(!d1) ? 'Op tijd!' : ('+' + $elm$core$String$fromInt(d1)))
+										$author$project$Main$plot(d1)
 									]);
 							}
 						}
@@ -7294,8 +12076,7 @@ var $author$project$Main$view = function (_v0) {
 								var d2 = _v11.b;
 								return _List_fromArray(
 									[
-										$elm$html$Html$text(
-										(!d2) ? 'Op tijd!' : ('+' + $elm$core$String$fromInt(d2)))
+										$author$project$Main$plot(d2)
 									]);
 							}
 						}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11683,29 +11683,37 @@ var $data_viz_lab$elm_chart_builder$Chart$Bar$render = F2(
 				return $elm$html$Html$text('');
 		}
 	});
-var $author$project$Main$plot = function (ls) {
-	return A2(
-		$data_viz_lab$elm_chart_builder$Chart$Bar$render,
-		_Utils_Tuple2(
-			ls,
-			{
-				xGroup: $elm$core$Basics$always($elm$core$Maybe$Nothing),
-				xValue: function (_v0) {
-					var p = _v0.a;
-					return $elm$core$String$fromInt(p) + ' min';
-				},
-				yValue: function (_v1) {
-					var f = _v1.b;
-					return f;
-				}
-			}),
-		$data_viz_lab$elm_chart_builder$Chart$Bar$init(
-			{
-				height: 200,
-				margin: {bottom: 30, left: 30, right: 10, top: 10},
-				width: 500
-			}));
-};
+var $author$project$Main$plot = F2(
+	function (ls, n) {
+		return A2(
+			$elm$html$Html$div,
+			_List_Nil,
+			_List_fromArray(
+				[
+					$elm$html$Html$text('Vertraging bij halte ' + (n + 'n')),
+					A2(
+					$data_viz_lab$elm_chart_builder$Chart$Bar$render,
+					_Utils_Tuple2(
+						ls,
+						{
+							xGroup: $elm$core$Basics$always($elm$core$Maybe$Nothing),
+							xValue: function (_v0) {
+								var p = _v0.a;
+								return $elm$core$String$fromInt(p) + ' min';
+							},
+							yValue: function (_v1) {
+								var f = _v1.b;
+								return f;
+							}
+						}),
+					$data_viz_lab$elm_chart_builder$Chart$Bar$init(
+						{
+							height: 200,
+							margin: {bottom: 30, left: 30, right: 10, top: 10},
+							width: 500
+						}))
+				]));
+	});
 var $elm$html$Html$select = _VirtualDom_node('select');
 var $author$project$Main$toDutchWeekday = function (t) {
 	return function () {
@@ -12176,7 +12184,10 @@ var $author$project$Main$view = function (_v0) {
 							var d2 = _v13.b;
 							return _List_fromArray(
 								[
-									$author$project$Main$plot(d1)
+									A2(
+									$author$project$Main$plot,
+									d1,
+									f(_Utils_Tuple0))
 								]);
 						}
 					}
@@ -12198,7 +12209,10 @@ var $author$project$Main$view = function (_v0) {
 							var d2 = _v16.b;
 							return _List_fromArray(
 								[
-									$author$project$Main$plot(d2)
+									A2(
+									$author$project$Main$plot,
+									d2,
+									f(_Utils_Tuple0))
 								]);
 						}
 					}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5529,6 +5529,19 @@ var $author$project$Main$addMinute = F2(
 					minute: ((m.minute + x) > 59) ? ((m.minute + x) - 60) : (m.minute + x)
 				}));
 	});
+var $elm$core$Tuple$second = function (_v0) {
+	var y = _v0.b;
+	return y;
+};
+var $author$project$Model$delayDataToFrequencies = function (ls) {
+	return _Utils_Tuple2(
+		ls,
+		A3(
+			$elm$core$List$foldr,
+			$elm$core$Basics$add,
+			0,
+			A2($elm$core$List$map, $elm$core$Tuple$second, ls)));
+};
 var $elm$core$Platform$Cmd$batch = _Platform_batch;
 var $elm$core$Platform$Cmd$none = $elm$core$Platform$Cmd$batch(_List_Nil);
 var $author$project$Msg$GotBuses = function (a) {
@@ -6861,13 +6874,18 @@ var $author$project$Main$update = F2(
 				default:
 					var res = msg.a;
 					if (res.$ === 'Ok') {
-						var dfdis = res.a;
+						var _v9 = res.a;
+						var d1 = _v9.a;
+						var d2 = _v9.b;
 						return _Utils_Tuple2(
 							$author$project$Model$Model(
 								_Utils_update(
 									m,
 									{
-										delays: $elm$core$Maybe$Just(dfdis),
+										delays: $elm$core$Maybe$Just(
+											_Utils_Tuple2(
+												$author$project$Model$delayDataToFrequencies(d1),
+												$author$project$Model$delayDataToFrequencies(d2))),
 										loading: $author$project$Model$NotLoading
 									})),
 							$elm$core$Platform$Cmd$none);
@@ -7340,10 +7358,6 @@ var $elm_community$list_extra$List$Extra$groupWhile = F2(
 			_List_Nil,
 			items);
 	});
-var $elm$core$Tuple$second = function (_v0) {
-	var y = _v0.b;
-	return y;
-};
 var $elm$core$List$sortWith = _List_sortWith;
 var $elm$core$String$toFloat = _String_toFloat;
 var $data_viz_lab$elm_chart_builder$Chart$Internal$Helpers$sortStrings = F2(
@@ -11683,8 +11697,60 @@ var $data_viz_lab$elm_chart_builder$Chart$Bar$render = F2(
 				return $elm$html$Html$text('');
 		}
 	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$StackedColumnTitle = function (a) {
+	return {$: 'StackedColumnTitle', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showStackedColumnTitle = F2(
+	function (formatter, _v0) {
+		var c = _v0.a;
+		return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
+			_Utils_update(
+				c,
+				{
+					showColumnTitle: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$StackedColumnTitle(formatter)
+				}));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$XOrdinalColumnTitle = {$: 'XOrdinalColumnTitle'};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showXOrdinalColumnTitle = function (_v0) {
+	var c = _v0.a;
+	return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
+		_Utils_update(
+			c,
+			{showColumnTitle: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$XOrdinalColumnTitle}));
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$YColumnTitle = function (a) {
+	return {$: 'YColumnTitle', a: a};
+};
+var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showYColumnTitle = F2(
+	function (formatter, _v0) {
+		var c = _v0.a;
+		return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
+			_Utils_update(
+				c,
+				{
+					showColumnTitle: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$YColumnTitle(formatter)
+				}));
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Bar$withColumnTitle = F2(
+	function (title, config) {
+		switch (title.$) {
+			case 'YColumnTitle':
+				var formatter = title.a;
+				return A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$showYColumnTitle, formatter, config);
+			case 'XOrdinalColumnTitle':
+				return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showXOrdinalColumnTitle(config);
+			case 'StackedColumnTitle':
+				var formatter = title.a;
+				return A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$showStackedColumnTitle, formatter, config);
+			default:
+				return config;
+		}
+	});
+var $data_viz_lab$elm_chart_builder$Chart$Bar$yColumnTitle = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$YColumnTitle;
 var $author$project$Main$plot = F2(
-	function (ls, n) {
+	function (_v0, n) {
+		var ls = _v0.a;
+		var tot = _v0.b;
 		return A2(
 			$elm$html$Html$div,
 			_List_Nil,
@@ -11697,21 +11763,25 @@ var $author$project$Main$plot = F2(
 						ls,
 						{
 							xGroup: $elm$core$Basics$always($elm$core$Maybe$Nothing),
-							xValue: function (_v0) {
-								var p = _v0.a;
+							xValue: function (_v1) {
+								var p = _v1.a;
 								return $elm$core$String$fromInt(p) + ' min';
 							},
-							yValue: function (_v1) {
-								var f = _v1.b;
-								return f;
+							yValue: function (_v2) {
+								var f = _v2.b;
+								return (f / tot) * 100;
 							}
 						}),
-					$data_viz_lab$elm_chart_builder$Chart$Bar$init(
-						{
-							height: 200,
-							margin: {bottom: 30, left: 30, right: 10, top: 10},
-							width: 500
-						}))
+					A2(
+						$data_viz_lab$elm_chart_builder$Chart$Bar$withColumnTitle,
+						$data_viz_lab$elm_chart_builder$Chart$Bar$yColumnTitle(
+							$elm$core$Basics$always('%')),
+						$data_viz_lab$elm_chart_builder$Chart$Bar$init(
+							{
+								height: 200,
+								margin: {bottom: 30, left: 30, right: 10, top: 10},
+								width: 500
+							})))
 				]));
 	});
 var $elm$html$Html$select = _VirtualDom_node('select');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5533,7 +5533,7 @@ var $elm$core$Tuple$second = function (_v0) {
 	var y = _v0.b;
 	return y;
 };
-var $author$project$Model$delayDataToFrequencies = function (ls) {
+var $author$project$Msg$delayDataToFrequencies = function (ls) {
 	return _Utils_Tuple2(
 		ls,
 		A3(
@@ -6466,9 +6466,18 @@ var $author$project$Main$requestDelays = function (_v0) {
 						['delays']),
 					_List_fromArray(
 						[
-							A2($elm$url$Url$Builder$int, 'departure', i1),
-							A2($elm$url$Url$Builder$int, 'destination', i2),
-							A2($elm$url$Url$Builder$int, 'bus', i3),
+							A2(
+							$elm$url$Url$Builder$int,
+							'departure',
+							i1(_Utils_Tuple0)),
+							A2(
+							$elm$url$Url$Builder$int,
+							'destination',
+							i2(_Utils_Tuple0)),
+							A2(
+							$elm$url$Url$Builder$int,
+							'bus',
+							i3(_Utils_Tuple0)),
 							A2(
 							$elm$url$Url$Builder$int,
 							'day',
@@ -6659,7 +6668,7 @@ var $author$project$Main$tryParseBus = F2(
 				var xprime = _v2.b;
 				return A2(
 					$author$project$Model$Bus,
-					i,
+					$elm$core$Basics$always(i),
 					$elm$core$Basics$always(xprime));
 			}
 		}
@@ -6688,7 +6697,7 @@ var $author$project$Main$tryParseStop = F2(
 				var xprime = _v2.b;
 				return A2(
 					$author$project$Model$Stop,
-					i,
+					$elm$core$Basics$always(i),
 					$elm$core$Basics$always(xprime));
 			}
 		}
@@ -6884,8 +6893,8 @@ var $author$project$Main$update = F2(
 									{
 										delays: $elm$core$Maybe$Just(
 											_Utils_Tuple2(
-												$author$project$Model$delayDataToFrequencies(d1),
-												$author$project$Model$delayDataToFrequencies(d2))),
+												$author$project$Msg$delayDataToFrequencies(d1),
+												$author$project$Msg$delayDataToFrequencies(d2))),
 										loading: $author$project$Model$NotLoading
 									})),
 							$elm$core$Platform$Cmd$none);
@@ -11697,56 +11706,6 @@ var $data_viz_lab$elm_chart_builder$Chart$Bar$render = F2(
 				return $elm$html$Html$text('');
 		}
 	});
-var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$StackedColumnTitle = function (a) {
-	return {$: 'StackedColumnTitle', a: a};
-};
-var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showStackedColumnTitle = F2(
-	function (formatter, _v0) {
-		var c = _v0.a;
-		return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
-			_Utils_update(
-				c,
-				{
-					showColumnTitle: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$StackedColumnTitle(formatter)
-				}));
-	});
-var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$XOrdinalColumnTitle = {$: 'XOrdinalColumnTitle'};
-var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showXOrdinalColumnTitle = function (_v0) {
-	var c = _v0.a;
-	return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
-		_Utils_update(
-			c,
-			{showColumnTitle: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$XOrdinalColumnTitle}));
-};
-var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$YColumnTitle = function (a) {
-	return {$: 'YColumnTitle', a: a};
-};
-var $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showYColumnTitle = F2(
-	function (formatter, _v0) {
-		var c = _v0.a;
-		return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$toConfig(
-			_Utils_update(
-				c,
-				{
-					showColumnTitle: $data_viz_lab$elm_chart_builder$Chart$Internal$Type$YColumnTitle(formatter)
-				}));
-	});
-var $data_viz_lab$elm_chart_builder$Chart$Bar$withColumnTitle = F2(
-	function (title, config) {
-		switch (title.$) {
-			case 'YColumnTitle':
-				var formatter = title.a;
-				return A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$showYColumnTitle, formatter, config);
-			case 'XOrdinalColumnTitle':
-				return $data_viz_lab$elm_chart_builder$Chart$Internal$Type$showXOrdinalColumnTitle(config);
-			case 'StackedColumnTitle':
-				var formatter = title.a;
-				return A2($data_viz_lab$elm_chart_builder$Chart$Internal$Type$showStackedColumnTitle, formatter, config);
-			default:
-				return config;
-		}
-	});
-var $data_viz_lab$elm_chart_builder$Chart$Bar$yColumnTitle = $data_viz_lab$elm_chart_builder$Chart$Internal$Type$YColumnTitle;
 var $author$project$Main$plot = F2(
 	function (_v0, n) {
 		var ls = _v0.a;
@@ -11772,16 +11731,12 @@ var $author$project$Main$plot = F2(
 								return (f / tot) * 100;
 							}
 						}),
-					A2(
-						$data_viz_lab$elm_chart_builder$Chart$Bar$withColumnTitle,
-						$data_viz_lab$elm_chart_builder$Chart$Bar$yColumnTitle(
-							$elm$core$Basics$always('%')),
-						$data_viz_lab$elm_chart_builder$Chart$Bar$init(
-							{
-								height: 200,
-								margin: {bottom: 30, left: 30, right: 10, top: 10},
-								width: 500
-							})))
+					$data_viz_lab$elm_chart_builder$Chart$Bar$init(
+						{
+							height: 200,
+							margin: {bottom: 30, left: 30, right: 10, top: 10},
+							width: 500
+						}))
 				]));
 	});
 var $elm$html$Html$select = _VirtualDom_node('select');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11692,7 +11692,7 @@ var $author$project$Main$plot = function (ls) {
 				xGroup: $elm$core$Basics$always($elm$core$Maybe$Nothing),
 				xValue: function (_v0) {
 					var p = _v0.a;
-					return $elm$core$String$fromInt(p);
+					return $elm$core$String$fromInt(p) + ' min';
 				},
 				yValue: function (_v1) {
 					var f = _v1.b;

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -215,7 +215,7 @@ view (Model m) = div [] [ -- Time changes, display in between - & +
                 ]
 
 plot : List (Int, Int) -> Html Msg
-plot ls = Chart.render (ls, {xGroup = always Nothing, xValue = (\(p, _) -> String.fromInt p), yValue = (\(_, f) -> toFloat f)}) (Chart.init { margin =
+plot ls = Chart.render (ls, {xGroup = always Nothing, xValue = (\(p, _) -> String.fromInt p ++ " min"), yValue = (\(_, f) -> toFloat f)}) (Chart.init { margin =
                                                                                                                                         { top = 10
                                                                                                                                         , right = 10
                                                                                                                                         , bottom = 30

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -212,27 +212,29 @@ view (Model m) = div [] ([ -- Time changes, display in between - & +
                         NoStop x -> []
                         Stop i f -> case m.delays of
                                       Nothing       -> []
-                                      Just (d1, d2) -> [plot d1])
+                                      Just (d1, d2) -> [plot d1 (f ())])
                 ++ (case m.destination of
                         NoStop x -> []
                         Stop i f -> case m.delays of
                                       Nothing       -> []
-                                      Just (d1, d2) -> [plot d2])
+                                      Just (d1, d2) -> [plot d2 (f ())])
                 )
-
-plot : List (Int, Int) -> Html Msg
-plot ls = Chart.render (ls, {xGroup = always Nothing,
-                             xValue = (\(p, _) -> String.fromInt p ++ " min"),
-                             yValue = (\(_, f) -> toFloat f)})
-                        (Chart.init { margin =
-                                        { top = 10
-                                        , right = 10
-                                        , bottom = 30
-                                        , left = 30
-                                        }
-                                    , width = 500
-                                    , height = 200
-                                    })
+-- | Plots the frequency distribution of delays at the given stop
+plot : List (Int, Int) -> String -> Html Msg
+plot ls n = div [] [text ("Vertraging bij halte " ++ n ++ "n"),
+                    Chart.render (ls, {xGroup = always Nothing,
+                                       xValue = (\(p, _) -> String.fromInt p ++ " min"),
+                                       yValue = (\(_, f) -> toFloat f)})
+                                 (Chart.init { margin =
+                                                  { top = 10
+                                                  , right = 10
+                                                  , bottom = 30
+                                                  , left = 30
+                                                  }
+                                              , width = 500
+                                              , height = 200
+                                              })
+                    ]
 
 -- | Subtracts up to 60 minutes from a given MomentInWeek. Does not change 'day' on wrap-around
 subMinute : MomentInWeek -> Int -> MomentInWeek

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -94,7 +94,7 @@ tryParseBus b dict = case b of
     Bus i f -> Bus i f
     NoBus x -> case Dict.get (String.toLower x) dict of
                Nothing          -> NoBus x
-               Just (i, xprime) -> Bus i (always xprime)
+               Just (i, xprime) -> Bus (always i) (always xprime)
 
 -- | Attempts to find the name in a stop field in its known dict of stops to create an identified stop
 tryParseStop : Stop -> Dict.Dict String (Int, String) -> Stop
@@ -102,7 +102,7 @@ tryParseStop s dict = case s of
     Stop i f -> Stop i f
     NoStop x -> case Dict.get (String.toLower x) dict of
                Nothing          -> NoStop x
-               Just (i, xprime) -> Stop i (always xprime)
+               Just (i, xprime) -> Stop (always i) (always xprime)
 
 -- | Creates the request to calculate the delays for this bus and these stops
 -- Idea to consider and discuss: don't send request if departure/destination are equal, or keep as feature instead to poll only a single stop
@@ -111,9 +111,9 @@ requestDelays (Model m) = case (m.departure, m.destination, m.bus) of
   (Stop i1 _, Stop i2 _, Bus i3 _) -> Http.request
     { method = "GET",
       headers = [],
-      url = Url.Builder.crossOrigin "http://localhost:3000" ["delays"] [Url.Builder.int "departure" i1,
-                                                                        Url.Builder.int "destination" i2,
-                                                                        Url.Builder.int "bus" i3,
+      url = Url.Builder.crossOrigin "http://localhost:3000" ["delays"] [Url.Builder.int "departure" (i1 ()),
+                                                                        Url.Builder.int "destination" (i2 ()),
+                                                                        Url.Builder.int "bus" (i3 ()),
                                                                         Url.Builder.int "day"    ((\(MomentInWeek momentInWeek) -> toDayNumber momentInWeek.day)    m.momentInWeek),
                                                                         Url.Builder.int "hour"   ((\(MomentInWeek momentInWeek) ->             momentInWeek.hour)   m.momentInWeek),
                                                                         Url.Builder.int "minute" ((\(MomentInWeek momentInWeek) ->             momentInWeek.minute) m.momentInWeek)

--- a/frontend/src/Model.elm
+++ b/frontend/src/Model.elm
@@ -2,7 +2,6 @@ module Model exposing (..)
 
 import Time
 import Dict
-import List exposing (map, foldr)
 
 type Model = Model {departure : Stop,
                     destination : Stop,
@@ -17,11 +16,11 @@ type Model = Model {departure : Stop,
 
 type MomentInWeek = MomentInWeek {day : Time.Weekday, hour : Int, minute : Int}
 
-type Stop = Stop Int (() -> String) --^ An identified stop, storing its id and a function that will always return the same string (to display the correct name)
-          | NoStop String           --^ Current value in the input field, not (yet) succesfully parsed as a stop
+type Stop = Stop (() -> Int) (() -> String) --^ An identified stop, storing functions that will always return the same id / string (to display the correct name)
+          | NoStop String                   --^ Current value in the input field, not (yet) succesfully parsed as a stop
 
-type Bus = Bus Int (() -> String) --^ An identified bus, storing its id and a function that will always return the same string (to display the correct name)
-         | NoBus String           --^ Current value in the input field, not (yet) succesfully parsed as a bus
+type Bus = Bus (() -> Int) (() -> String) --^ An identified bus, storing functions that will always return the same id / string (to display the correct name)
+         | NoBus String                   --^ Current value in the input field, not (yet) succesfully parsed as a bus
 
 -- | Whether we're waiting on a response from the server.
 -- Currently tracked but not used
@@ -30,9 +29,6 @@ type LoadingState = Loading
 
 -- | Punctualities, Frequencies + Sum of Frequencies
 type alias DelayFrequencies = (List (Int, Int), Int)
-
-delayDataToFrequencies : List (Int, Int) -> DelayFrequencies
-delayDataToFrequencies ls = (ls, foldr (+) 0 (map Tuple.second ls))
 
 -- | Sorted frequency distribution of the delays at (departure, destination), in format (punctuality, frequency)
 type alias DelayInfo = Maybe (DelayFrequencies, DelayFrequencies)

--- a/frontend/src/Model.elm
+++ b/frontend/src/Model.elm
@@ -2,6 +2,7 @@ module Model exposing (..)
 
 import Time
 import Dict
+import List exposing (map, foldr)
 
 type Model = Model {departure : Stop,
                     destination : Stop,
@@ -27,5 +28,11 @@ type Bus = Bus Int (() -> String) --^ An identified bus, storing its id and a fu
 type LoadingState = Loading
                   | NotLoading
 
+-- | Punctualities, Frequencies + Sum of Frequencies
+type alias DelayFrequencies = (List (Int, Int), Int)
+
+delayDataToFrequencies : List (Int, Int) -> DelayFrequencies
+delayDataToFrequencies ls = (ls, foldr (+) 0 (map Tuple.second ls))
+
 -- | Sorted frequency distribution of the delays at (departure, destination), in format (punctuality, frequency)
-type alias DelayInfo = Maybe (List (Int, Int), List (Int, Int))
+type alias DelayInfo = Maybe (DelayFrequencies, DelayFrequencies)

--- a/frontend/src/Model.elm
+++ b/frontend/src/Model.elm
@@ -27,5 +27,5 @@ type Bus = Bus Int (() -> String) --^ An identified bus, storing its id and a fu
 type LoadingState = Loading
                   | NotLoading
 
--- | Average delay in minutes at (departure, destination)
-type alias DelayInfo = Maybe (Int, Int)
+-- | Sorted frequency distribution of the delays at (departure, destination), in format (punctuality, frequency)
+type alias DelayInfo = Maybe (List (Int, Int), List (Int, Int))

--- a/frontend/src/Msg.elm
+++ b/frontend/src/Msg.elm
@@ -2,6 +2,9 @@ module Msg exposing (..)
 
 import Time
 import Http
+import List exposing (map, foldr)
+
+import Model exposing (..)
 
 type Msg = -- Input changes
            BusChange String
@@ -34,6 +37,9 @@ type TimeMod = PlusHour
              | Minus15Min
              | Plus5Min
              | Minus5Min
+
+delayDataToFrequencies : List (Int, Int) -> DelayFrequencies
+delayDataToFrequencies ls = (ls, foldr (+) 0 (map Tuple.second ls))
 
 -- | Encodes weekday as int for query.
 -- Week starts at Monday, index 0, and so on.

--- a/frontend/src/Msg.elm
+++ b/frontend/src/Msg.elm
@@ -12,9 +12,6 @@ type Msg = -- Input changes
          | DayChange Time.Weekday
          | TimeChange TimeMod
          | ReverseStops
-         -- | Check that input in bus/stop field represents a valid bus/stop
-         | ValidateBus
-         | ValidateStop RouteEndpoint
          -- Request delay calculation
          | CalcDelay
          -- To set the default time to local time, not used afterwards

--- a/frontend/src/Msg.elm
+++ b/frontend/src/Msg.elm
@@ -39,10 +39,10 @@ type TimeMod = PlusHour
 -- Week starts at Monday, index 0, and so on.
 toDayNumber : Time.Weekday -> Int
 toDayNumber t = case t of
-                  Time.Mon -> 0
-                  Time.Tue -> 1
-                  Time.Wed -> 2
-                  Time.Thu -> 3
-                  Time.Fri -> 4
-                  Time.Sat -> 5
-                  Time.Sun -> 6
+                  Time.Mon -> 1
+                  Time.Tue -> 2
+                  Time.Wed -> 3
+                  Time.Thu -> 4
+                  Time.Fri -> 5
+                  Time.Sat -> 6
+                  Time.Sun -> 7

--- a/frontend/src/Msg.elm
+++ b/frontend/src/Msg.elm
@@ -21,7 +21,7 @@ type Msg = -- Input changes
          | GotStops (Result Http.Error (List (String, Int)))
          | GotBuses (Result Http.Error (List (String, Int)))
          -- Delay request
-         | GotDelays (Result Http.Error (Int, Int))
+         | GotDelays (Result Http.Error (List (Int, Int), List (Int, Int)))
 
 -- | Whether functionality involving a stop should work on the departure or destination stop
 type RouteEndpoint = Departure

--- a/src/ExampleData.hs
+++ b/src/ExampleData.hs
@@ -28,4 +28,4 @@ busData = Buses $ map toBusPair exampleBuses
 
 delayData :: Delays
 delayData = Delays { departureDelays   = [DelayFrequency (-3) 1, DelayFrequency (-1) 3, DelayFrequency 0 8, DelayFrequency 1 4, DelayFrequency 3 3]
-                   , destinationDelays = [DelayFrequency (-2) 1, DelayFrequency 0 2, DelayFrequency 4 3, DelayFrequency 5 10, DelayFrequency 6 3]}
+                       , destinationDelays = [DelayFrequency (-2) 1, DelayFrequency 0 2, DelayFrequency 4 3, DelayFrequency 5 10, DelayFrequency 6 3]}

--- a/src/ExampleData.hs
+++ b/src/ExampleData.hs
@@ -27,4 +27,5 @@ busData :: Buses
 busData = Buses $ map toBusPair exampleBuses
 
 delayData :: Delays
-delayData = Delays {departureDelay = 2, destinationDelay = 4}
+delayData = Delays { departureDelays   = [DelayFrequency (-3) 1, DelayFrequency (-1) 3, DelayFrequency 0 8, DelayFrequency 1 4, DelayFrequency 3 3]
+                   , destinationDelays = [DelayFrequency (-2) 1, DelayFrequency 0 2, DelayFrequency 4 3, DelayFrequency 5 10, DelayFrequency 6 3]}

--- a/src/MessageFormat.hs
+++ b/src/MessageFormat.hs
@@ -10,7 +10,7 @@ import Data.Text (unpack)
 import Data.Text.Encoding (decodeUtf8)
 import Data.List
 import Text.Read
-import Data.Time.Calendar
+import Data.Time (DayOfWeek)
 
 data StopPair = StopPair {stopName :: String, stopId :: Int} deriving Generic
 data Stops = Stops {stops :: [StopPair]} deriving Generic
@@ -34,10 +34,13 @@ instance ToJSON Buses where
 toBusPair :: (String, Int) -> BusPair
 toBusPair (s, i) = BusPair s i
 
+data DelayFrequency = DelayFrequency {punct :: Int, freq:: Int} deriving Generic
+instance ToJSON DelayFrequency where
+
 data Delays = Delays { -- | Average delay at the departure stop, in minutes
-                      departureDelay :: Int,
+                      departureDelays :: [DelayFrequency],
                       -- | Average delay at the destination stop, in minutes
-                      destinationDelay :: Int} deriving Generic
+                      destinationDelays :: [DelayFrequency]} deriving Generic
 instance ToJSON Delays where
 
 data DelayRequest = DelayRequest { -- | Id of queried departure stop
@@ -48,16 +51,9 @@ data DelayRequest = DelayRequest { -- | Id of queried departure stop
                                   bus :: Int, weekday :: DayOfWeek, hour :: Int, minute :: Int}
 
 -- | Tries to parse a string to a weekday according to the encoded representation.
--- Week starts at Monday, index 0, and so on.
+-- Week starts at Monday, index 1, and so on.
 validWeekday :: String -> Maybe DayOfWeek
-validWeekday "0" = Just Monday
-validWeekday "1" = Just Tuesday
-validWeekday "2" = Just Wednesday
-validWeekday "3" = Just Thursday
-validWeekday "4" = Just Friday
-validWeekday "5" = Just Saturday
-validWeekday "6" = Just Sunday
-validWeekday  _  = Nothing
+validWeekday = Just . toEnum . read
 
 -- | Turns numbers outside the valid hour range (0-23) into Nothing.
 validHour :: Int -> Maybe Int


### PR DESCRIPTION
Updates the message format to send the already calculated frequency distributions over.
Updates the frontend accordingly to show a bar chart of the distribution.
Example: 
![image](https://github.com/Davvos11/afp-project/assets/57987812/47ddf49c-e523-4ccd-8395-8b7f568a7959)

**Before merging:**
- [x] Place charts in different position (they appear out of nowhere and move the rest of the interface about)
- [x] Have yscale based on % of the distribution, not raw frequency (would scale bad for bigger datasets)

**Before or after:**
- [ ] Prettify (it's *award winning design* atm)
- [x] Make autocomplete not call update an additional time (seems to lag)